### PR TITLE
Support SSL in database connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Hanna
-Hanna is a project management application. It is designed and built initially for the needs of KAPA and KITIA, but with capabilities of expanding to other departments' needs in the future. 
+Hanna is a project management application. It is designed and built initially for the needs of KAPA and KITIA, but with capabilities of expanding to other departments' needs in the future.
 
-Minimum implementation is planned to be finished by 2023 and the software with full functionality and integration list by July 2023. 
+Minimum implementation is planned to be finished by 2023 and the software with full functionality and integration list by July 2023.
 
 ## Development
 
 - Steps required when running for the first time
-  * `cp backend/.env.template backend/.env`
-  * See the `.env.template` file to check if you need to replace or fill some initial values
+  * `cp backend/.template.env backend/.env`
+  * See the `.template.env` file to check if you need to replace or fill some initial values
 
 When `backend/.env` is properly set, start the development by running:
 
@@ -44,4 +44,4 @@ NOTE! Due to using https on development at localhost, Caddy Root Certificate nee
 - After starting the Caddy proxy (via docker compose) for the first time, root certificate can be found from `PROJECT_ROOT/docker/proxy/data/caddy/pki/authorities/local/root.crt`
 - MacOS users:  ```open ./docker/proxy/data/caddy/pki/authorities/local/root.crt```
   - Open the root file in Keychain Access
-  - Find the Caddy Root CA using the search and right-clicking it, then select *Get Info* and expand  the *Trust* section. Finally set SSL setting to *Always Trust* 
+  - Find the Caddy Root CA using the search and right-clicking it, then select *Get Info* and expand  the *Trust* section. Finally set SSL setting to *Always Trust*

--- a/backend/.template.env
+++ b/backend/.template.env
@@ -10,6 +10,7 @@ PG_PORT=5432
 PG_USER=app_user_dev
 PG_PASS=DevPassword
 PG_DATABASE=app_dev_db
+PG_SSLMODE=disable
 
 # OIDC
 OIDC_CLIENT_DISCOVERY_URL=http://localhost:9090

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -19,18 +19,21 @@ export class SharedPool extends Pool {
   }
 }
 
-const connectionDsn = stringifyDsn({
-  databaseName: env.db.database,
-  host: env.db.host,
-  port: env.db.port,
-  username: env.db.username,
-  password: env.db.password,
-});
+const connectionDsn =
+  stringifyDsn({
+    databaseName: env.db.database,
+    host: env.db.host,
+    port: env.db.port,
+    username: env.db.username,
+    password: env.db.password,
+  }) + `?sslmode=${env.db.sslMode}`;
 
 let pool: DatabasePool | null = null;
 
 export async function createDatabasePool() {
-  const redactedDsn = connectionDsn.replace(env.db.password, '********');
+  // The password in DSN may include URI decoded characters
+  const uriEncodedPassword = encodeURIComponent(env.db.password);
+  const redactedDsn = connectionDsn.replace(uriEncodedPassword, '********');
   logger.info(`Connecting to ${redactedDsn}`);
   pool = await createPool(connectionDsn, { PgPool: SharedPool });
 }

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -4,7 +4,9 @@ import { z } from 'zod';
 if (process.env.NODE_ENV === 'development') {
   try {
     require('../.env');
-  } catch (err) {}
+  } catch (err) {
+    // Ignore errors - only used for restarting server on .env changes
+  }
 }
 
 const schema = z.object({
@@ -18,6 +20,7 @@ const schema = z.object({
     database: z.string(),
     username: z.string(),
     password: z.string(),
+    sslMode: z.enum(['disable', 'no-verify', 'require']),
   }),
   oidc: z.object({
     discovery_url: z.string(),
@@ -39,6 +42,7 @@ function getEnv() {
       database: process.env.PG_DATABASE,
       username: process.env.PG_USER,
       password: process.env.PG_PASS,
+      sslMode: process.env.PG_SSLMODE || 'disable',
     },
     oidc: {
       discovery_url: process.env.OIDC_CLIENT_DISCOVERY_URL,


### PR DESCRIPTION
- Added `PG_SSLMODE` env for using SSL in database connections (required by Azure PostgreSQL)
- Renamed `.env.template` to `.template.env` to enable automatic syntax highlighting
- Fixed a problem with redacting DB password with special characters