### PR TITLE
Fixed date picker keyboard input on Chrome

### DIFF
--- a/frontend/src/components/forms/index.tsx
+++ b/frontend/src/components/forms/index.tsx
@@ -84,10 +84,20 @@ export function FormDatePicker({ field, readOnly }: FormDatePickerProps) {
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <DesktopDatePicker<Dayjs>
         readOnly={readOnly}
+        /**
+         * Chrome interprets unfinished date strings as valid (e.g. new Date("1") resolves to 2001-01-01) and this
+         * breaks the date picker's keyboard input.
+         *
+         * However, when the underlying input's onChange callback is overridden, the Chrome's faulty date parsing doesn't seem to get called
+         * and everything works just fine.
+         */
+        InputProps={{
+          onChange: () => null,
+        }}
         inputFormat={tr['date.inputFormat']}
         value={field.value ? dayjs(field.value) : null}
-        onChange={(val) => field.onChange(val?.toDate())}
-        onAccept={(val) => field.onChange(val?.toDate())}
+        onChange={(val) => field.onChange(val?.toDate() ?? null)}
+        onAccept={(val) => field.onChange(val?.toDate() ?? null)}
         onClose={field.onBlur}
         renderInput={(props) => {
           return <TextField {...(readOnly && readonlyProps)} {...field} {...props} size="small" />;

--- a/frontend/src/views/Project/Project.tsx
+++ b/frontend/src/views/Project/Project.tsx
@@ -211,8 +211,7 @@ const infobarRootStyle = css`
 `;
 
 const mapContainerStyle = css`
-  padding: 16px;
-  height: 600px;
+  min-height: 600px;
 `;
 
 const accordionSummaryStyle = css`
@@ -226,7 +225,7 @@ export function Project() {
   const projectId = routeParams?.projectId;
   const project = trpc.project.get.useQuery(
     { id: projectId },
-    { enabled: Boolean(projectId), queryKey: ['project.get', projectId] }
+    { enabled: Boolean(projectId), queryKey: ['project.get', { id: projectId }] }
   );
 
   if (projectId && !project.data) {

--- a/frontend/src/views/Project/Projects.tsx
+++ b/frontend/src/views/Project/Projects.tsx
@@ -143,8 +143,8 @@ function SearchResults({ results }: SearchResultsProps) {
                       {result.projectName}
                     </Typography>
                     <Typography sx={{ lineHeight: '120%' }} variant="overline">
-                      {result.startDate.toLocaleDateString()} —{' '}
-                      {result.endDate.toLocaleDateString()}
+                      {result.startDate.toLocaleDateString('fi')} —
+                      {result.endDate.toLocaleDateString('fi')}
                     </Typography>
                   </Box>
                 </Card>
@@ -160,8 +160,7 @@ function SearchResults({ results }: SearchResultsProps) {
 }
 
 const resultMapContainerStyle = css`
-  padding: 16px;
-  height: 600px;
+  min-height: 600px;
 `;
 
 function ResultsMap() {


### PR DESCRIPTION
- Prevent the date picker from using Chrome's built-in `new Date()`, which incorrectly parses an incomplete date as a valid date
- Allow empty values in date picker
- Tweaked map styles (stretch vertically to grid, removed padding)