### PR TITLE
Fixed timezone issues in start & end date fields

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,4 +107,4 @@ jobs:
       url: ${{ needs.build.outputs.app_url }}
     steps:
       - name: Deploy
-        run: curl -X POST ${{ secrets.DEPLOY_WEBHOOK_URL }}
+        run: curl --fail -X POST '${{ secrets.DEPLOY_WEBHOOK_URL }}'

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -37,14 +37,6 @@ export async function createDatabasePool() {
   logger.info(`Connecting to ${redactedDsn}`);
   pool = await createPool(connectionDsn, {
     PgPool: SharedPool,
-    typeParsers: [
-      {
-        name: 'date',
-        parse: (value) => {
-          return new Date(value);
-        },
-      },
-    ],
   });
 }
 

--- a/backend/src/router/project.ts
+++ b/backend/src/router/project.ts
@@ -39,8 +39,8 @@ async function upsertProject(project: UpsertProject) {
       SET
         project_name = ${projectName},
         description = ${description},
-        start_date = ${startDate.toISOString()},
-        end_date = ${endDate.toISOString()}
+        start_date = ${startDate},
+        end_date = ${endDate}
       WHERE id = ${id}
       RETURNING id
     `);
@@ -49,7 +49,7 @@ async function upsertProject(project: UpsertProject) {
     const result = await getPool().one(
       sql`
         INSERT INTO app.project (project_name, description, start_date, end_date)
-        VALUES (${projectName}, ${description}, ${startDate.toISOString()}, ${endDate.toISOString()})
+        VALUES (${projectName}, ${description}, ${startDate}, ${endDate})
         RETURNING id
       `
     );

--- a/frontend/src/components/forms/index.tsx
+++ b/frontend/src/components/forms/index.tsx
@@ -95,9 +95,9 @@ export function FormDatePicker({ field, readOnly }: FormDatePickerProps) {
           onChange: () => null,
         }}
         inputFormat={tr['date.inputFormat']}
-        value={field.value ? dayjs(field.value) : null}
-        onChange={(val) => field.onChange(val?.toDate() ?? null)}
-        onAccept={(val) => field.onChange(val?.toDate() ?? null)}
+        value={field.value ? dayjs(field.value, 'YYYY-MM-DD') : null}
+        onChange={(val) => field.onChange(val?.format('YYYY-MM-DD') ?? null)}
+        onAccept={(val) => field.onChange(val?.format('YYYY-MM-DD') ?? null)}
         onClose={field.onBlur}
         renderInput={(props) => {
           return <TextField {...(readOnly && readonlyProps)} {...field} {...props} size="small" />;

--- a/shared/schema/project.ts
+++ b/shared/schema/project.ts
@@ -4,8 +4,8 @@ export const upsertProjectSchema = z.object({
   id: z.string().optional(),
   projectName: z.string().min(1),
   description: z.string().min(1),
-  startDate: z.date(),
-  endDate: z.date(),
+  startDate: z.string().regex(/\d{4}-\d{2}-\d{2}/),
+  endDate: z.string().regex(/\d{4}-\d{2}-\d{2}/),
 });
 
 export type UpsertProject = z.infer<typeof upsertProjectSchema>;


### PR DESCRIPTION
Date-only fields are now handled as strings outside database to avoid any timezone problems.

Also attempting to fix automatic deployment by wrapping the webhook URL in single quotes.