### PR TITLE
HankeTyyppi field, search and tests

### DIFF
--- a/backend/db_migrations/0016_project_new-fields.sql
+++ b/backend/db_migrations/0016_project_new-fields.sql
@@ -1,0 +1,38 @@
+INSERT INTO code(id, text_fi, text_en)
+VALUES
+(('HankeTyyppi', '01'), 'Yleiskaava', 'Yleiskaava'),
+(('HankeTyyppi', '02'), 'Hankekehitys', 'Hankekehitys'),
+(('HankeTyyppi', '03'), 'Asemakaava', 'Asemakaava'),
+(('HankeTyyppi', '04'), 'Investointihanke', 'Investointihanke'),
+(('HankeTyyppi', '05'), 'Ylläpito', 'Ylläpito'),
+(('Lautakunta', '01'), 'Yhdyskuntalautakunta', 'Yhdyskuntalautakunta'),
+(('Lautakunta', '02'), 'Asunto- ja kiinteistölautakunta', 'Asunto- ja kiinteistölautakunta'),
+(('Lautakunta', '03'), 'Elinkeino- ja osaamislautakunta', 'Elinkeino- ja osaamislautakunta'),
+(('Lautakunta', '04'), 'Joukkoliikennelautakunta', 'Joukkoliikennelautakunta');
+
+ALTER TABLE project ADD COLUMN project_type code_id;
+
+-- set existing projects to have project type before adding constraint
+UPDATE project
+SET project_type = ('HankeTyyppi', '02');
+
+-- remove now obsolete code list that is replaced with more up to date value set
+DELETE FROM code
+WHERE (id).code_list_id = 'Hanketyyppi';
+
+ALTER TABLE project ALTER COLUMN project_type SET NOT NULL;
+
+ALTER TABLE project ADD CONSTRAINT project_type_check CHECK (
+  (project_type).code_list_id = 'HankeTyyppi'
+);
+
+ALTER TABLE project ADD CONSTRAINT project_type_fk FOREIGN KEY (project_type)
+REFERENCES code(id) ON DELETE RESTRICT;
+
+CREATE TABLE project_committee (
+  project_id uuid NOT NULL REFERENCES project(id) ON DELETE CASCADE,
+  committee_type code_id NOT NULL CHECK (
+    (committee_type).code_list_id = 'Lautakunta'
+  ) REFERENCES code(id) ON DELETE RESTRICT,
+  PRIMARY KEY (project_id, committee_type)
+);

--- a/backend/src/router/projectObject.ts
+++ b/backend/src/router/projectObject.ts
@@ -1,11 +1,11 @@
 import { TRPCError } from '@trpc/server';
 import { sql } from 'slonik';
-import { CodeId } from 'tre-hanna-shared/src/schema/code';
 import { z } from 'zod';
 
 import { getPool } from '@backend/db';
 import { TRPC } from '@backend/router';
 
+import { CodeId } from '@shared/schema/code';
 import {
   UpsertProjectObject,
   dbProjectObjectSchema,

--- a/e2e/test/api/code.test.ts
+++ b/e2e/test/api/code.test.ts
@@ -11,10 +11,10 @@ test.describe('Code endpoints', () => {
   });
 
   test('get codes for a list', async () => {
-    const codeListId: Code['codeListId'] = 'Hanketyyppi';
+    const codeListId: Code['id']['codeListId'] = 'HankeTyyppi';
 
     const codes = await client.code.get.query({ codeListId });
     expect(Array.isArray(codes)).toBe(true);
-    expect(codes.every((code) => code.codeListId === codeListId));
+    expect(codes.every((code) => code.id.codeListId === codeListId));
   });
 });

--- a/e2e/test/api/project.test.ts
+++ b/e2e/test/api/project.test.ts
@@ -28,6 +28,7 @@ test.describe('Project endpoints', () => {
       startDate: '2021-01-01',
       endDate: '2022-01-01',
       lifecycleState: '01',
+      projectType: '01',
     });
 
     const point = makePoint(24487416.69375355, 6821004.272996133, 'EPSG:3878');

--- a/e2e/test/project.test.ts
+++ b/e2e/test/project.test.ts
@@ -51,15 +51,14 @@ async function createProject(page: Page, project: UpsertProject) {
   await page.locator('textarea[name="description"]').fill(project.description);
   await page.locator('input[name="startDate"]').fill(project.startDate);
   await page.locator('input[name="endDate"]').fill(project.endDate);
-
   const lifecycleText = lifecycleStateToText[project.lifecycleState];
   if (lifecycleText) {
-    await page.getByRole('combobox').click();
-    await page.getByRole('combobox').fill('');
-    await page.getByRole('combobox').fill(lifecycleText);
-    await page.getByRole('combobox').press('ArrowDown');
-    await page.getByRole('combobox').press('Enter');
+    await page.getByLabel('Elinkaaren tila').click();
+    await page.getByRole('option', { name: lifecycleText }).click();
   }
+
+  await page.getByLabel('Hanketyyppi').click();
+  await page.getByRole('option', { name: 'Investointihanke' }).click();
 
   await page.getByRole('button', { name: 'Lisää hanke' }).click();
 

--- a/frontend/src/components/forms/DatePicker.tsx
+++ b/frontend/src/components/forms/DatePicker.tsx
@@ -9,6 +9,7 @@ import { useAtomValue } from 'jotai';
 import { langAtom, useTranslations } from '@frontend/stores/lang';
 
 interface Props {
+  id?: string;
   value: string | null;
   onChange: (value: string | null) => void;
   onClose?: () => void;
@@ -21,7 +22,7 @@ interface Props {
 const isoDateStringFormat = 'YYYY-MM-DD';
 
 export function DatePicker(props: Props) {
-  const { value, onChange, onClose, readOnly, minDate, maxDate, InputProps } = props;
+  const { id, value, onChange, onClose, readOnly, minDate, maxDate, InputProps } = props;
   const tr = useTranslations();
   const lang = useAtomValue(langAtom);
   const readonlyProps = {
@@ -65,6 +66,7 @@ export function DatePicker(props: Props) {
               inputProps={{
                 ...props.inputProps,
                 placeholder: tr('date.format.placeholder'),
+                id,
               }}
             />
           );

--- a/frontend/src/components/forms/index.tsx
+++ b/frontend/src/components/forms/index.tsx
@@ -14,16 +14,18 @@ import {
 import { DatePicker } from './DatePicker';
 
 interface CustomFormLabelProps {
+  htmlFor?: string;
   label?: string;
   tooltip?: string;
   error?: FieldError;
 }
 
-export function CustomFormLabel({ label, tooltip, error }: CustomFormLabelProps) {
+export function CustomFormLabel({ htmlFor, label, tooltip, error }: CustomFormLabelProps) {
   const [open, setOpen] = useState(true);
 
   return (
     <FormLabel
+      htmlFor={htmlFor}
       error={Boolean(error)}
       css={css`
         display: flex;
@@ -39,6 +41,7 @@ export function CustomFormLabel({ label, tooltip, error }: CustomFormLabelProps)
           css={css`
             border-bottom: 2px dotted red;
             cursor: pointer;
+            z-index: 400;
           `}
           title={error.type === 'custom' ? error.message : tooltip}
         >
@@ -53,7 +56,9 @@ interface FormFieldProps {
   formField: string;
   label?: string;
   tooltip?: string;
-  component: (field: ControllerRenderProps<FieldValues, string>) => React.ReactElement;
+  component: (
+    field: ControllerRenderProps<FieldValues, string> & { id?: string }
+  ) => React.ReactElement;
 }
 
 export function FormField({ formField, label, tooltip, component }: FormFieldProps) {
@@ -65,8 +70,13 @@ export function FormField({ formField, label, tooltip, component }: FormFieldPro
       control={control}
       render={({ field, fieldState }) => (
         <FormControl margin="dense">
-          <CustomFormLabel label={label} tooltip={tooltip} error={fieldState.error} />
-          {component(field)}
+          <CustomFormLabel
+            htmlFor={formField}
+            label={label}
+            tooltip={tooltip}
+            error={fieldState.error}
+          />
+          {component({ ...field, id: formField })}
         </FormControl>
       )}
     />
@@ -74,7 +84,7 @@ export function FormField({ formField, label, tooltip, component }: FormFieldPro
 }
 
 interface FormDatePickerProps {
-  field: ControllerRenderProps<FieldValues, string>;
+  field: ControllerRenderProps<FieldValues, string> & { id?: string };
   readOnly?: boolean;
   minDate?: Dayjs;
   maxDate?: Dayjs;
@@ -82,6 +92,7 @@ interface FormDatePickerProps {
 export function FormDatePicker({ field, readOnly, minDate, maxDate }: FormDatePickerProps) {
   return (
     <DatePicker
+      id={field.id}
       InputProps={{ name: field.name }}
       value={field.value}
       onChange={(value) => field.onChange(value)}

--- a/frontend/src/stores/lang/en.json
+++ b/frontend/src/stores/lang/en.json
@@ -33,6 +33,7 @@
   "newProject.startDateTooltip": "Select project start date",
   "newProject.endDateTooltip": "Select project end date",
   "newProject.lifecycleStateTooltip": "Select project lifecycle state",
+  "newProject.projectTypeTooltip": "Select project type",
   "newProject.basicInfoSectionLabel": "Information",
   "newProject.createBtnLabel": "Add project",
   "newProject.linksSectionTitle": "Related projects",

--- a/frontend/src/stores/lang/fi.json
+++ b/frontend/src/stores/lang/fi.json
@@ -33,6 +33,7 @@
   "newProject.startDateTooltip": "Valitse hankkeen alkuajankohta",
   "newProject.endDateTooltip": "Valitse hankkeen loppuajankohta",
   "newProject.lifecycleStateTooltip": "Valitse elinkaaren tila",
+  "newProject.projectTypeTooltip": "Valitse hanketyyppi",
   "newProject.basicInfoSectionLabel": "Perustiedot",
   "newProject.createBtnLabel": "Lisää hanke",
   "newProject.linksSectionTitle": "Sidoshankkeet",

--- a/frontend/src/stores/search/project.ts
+++ b/frontend/src/stores/search/project.ts
@@ -15,6 +15,7 @@ export const projectSearchParamAtoms = {
   lifecycleStates: atom<string[]>([]),
   projectTypes: atom<string[]>([]),
   financingTypes: atom<string[]>([]),
+  committee: atom<string[]>([]),
   map: atom<MapSearch>({
     zoom: mapOptions.tre.defaultZoom,
     extent: mapOptions.tre.extent,

--- a/frontend/src/views/Project/ProjectForm.tsx
+++ b/frontend/src/views/Project/ProjectForm.tsx
@@ -194,12 +194,28 @@ export function ProjectForm(props: ProjectFormProps) {
           formField="lifecycleState"
           label={tr('project.lifecycleStateLabel')}
           tooltip={tr('newProject.lifecycleStateTooltip')}
-          component={({ onChange, value }) => (
+          component={({ id, onChange, value }) => (
             <CodeSelect
+              id={id}
               value={value}
               onChange={onChange}
               readOnly={!editing}
               codeListId="HankkeenElinkaarentila"
+            />
+          )}
+        />
+
+        <FormField
+          formField="projectType"
+          label={tr('project.projectTypeLabel')}
+          tooltip={tr('newProject.projectTypeTooltip')}
+          component={({ id, onChange, value }) => (
+            <CodeSelect
+              id={id}
+              value={value}
+              onChange={onChange}
+              readOnly={!editing}
+              codeListId="HankeTyyppi"
             />
           )}
         />

--- a/frontend/src/views/Project/ResultsMap.tsx
+++ b/frontend/src/views/Project/ResultsMap.tsx
@@ -8,11 +8,12 @@ import Stroke from 'ol/style/Stroke';
 import Style from 'ol/style/Style';
 import Text from 'ol/style/Text';
 import { useEffect, useMemo } from 'react';
-import { ProjectSearchResult } from 'tre-hanna-shared/src/schema/project';
 
 import { MapWrapper } from '@frontend/components/Map/MapWrapper';
 import { addFeaturesFromGeoJson, drawStyle } from '@frontend/components/Map/mapInteractions';
 import { getProjectSearchParamSetters } from '@frontend/stores/search/project';
+
+import { ProjectSearchResult } from '@shared/schema/project';
 
 const resultMapContainerStyle = css`
   min-height: 600px;

--- a/frontend/src/views/Project/SearchControls.tsx
+++ b/frontend/src/views/Project/SearchControls.tsx
@@ -110,7 +110,7 @@ export function SearchControls() {
         <FormLabel htmlFor="project-type">{tr('project.projectTypeLabel')}</FormLabel>
         <CodeSelect
           id="project-type"
-          codeListId="Hanketyyppi"
+          codeListId="HankeTyyppi"
           multiple
           value={searchParams.projectTypes}
           onChange={setSearchParams.projectTypes}
@@ -133,7 +133,12 @@ export function SearchControls() {
           </FormControl>
           <FormControl>
             <FormLabel>{tr('project.committeeLabel')}</FormLabel>
-            <Select disabled size="small"></Select>
+            <CodeSelect
+              codeListId="Lautakunta"
+              multiple
+              value={searchParams.committee}
+              onChange={setSearchParams.committee}
+            />
           </FormControl>
           <FormControl>
             <FormLabel>{tr('project.ownerLabel')}</FormLabel>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -22,7 +22,9 @@ export default defineConfig({
         typescript: {
           buildMode: true,
         },
-        overlay: false,
+        overlay: {
+          initialIsOpen: false,
+        },
       }),
   ],
   build: {

--- a/shared/src/schema/code.ts
+++ b/shared/src/schema/code.ts
@@ -8,7 +8,7 @@ export const codeId = z.string().regex(codeIdRegex);
 
 const codeListIdSchema = z.enum([
   'Rahoitusmalli',
-  'Hanketyyppi',
+  'HankeTyyppi',
   'LiittyvanHankkeenTyyppi',
   'HankkeenElinkaarentila',
   'HankkeenToimielin',
@@ -18,6 +18,7 @@ const codeListIdSchema = z.enum([
   'KohteenToiminnallinenKayttoTarkoitus',
   'KohteenMaanomistusLaji',
   'KohteenSuhdePeruskiinteistoon',
+  'Lautakunta',
 ]);
 
 export const codeIdSchema = z.object({

--- a/shared/src/schema/common.ts
+++ b/shared/src/schema/common.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod';
 
-import { isoDateStringRegex } from '../utils';
-
 export const nonEmptyString = z
   .string()
   .min(1)
   .refine((value) => value.trim().length > 0, {});
+
+const isoDateStringRegex = /\d{4}-\d{2}-\d{2}/;
 
 export const isoDateString = z.string().regex(isoDateStringRegex);

--- a/shared/src/schema/project.ts
+++ b/shared/src/schema/project.ts
@@ -1,21 +1,23 @@
 import { z } from 'zod';
 
-import { isoDateStringRegex } from '../utils';
+import { codeId } from './code';
+import { isoDateString, nonEmptyString } from './common';
 
 export const upsertProjectSchema = z.object({
   id: z.string().optional(),
-  projectName: z.string().min(1),
-  description: z.string().min(1),
-  startDate: z.string().regex(isoDateStringRegex),
-  endDate: z.string().regex(isoDateStringRegex),
-  lifecycleState: z.enum(['01', '02', '03', '04']),
+  projectName: nonEmptyString,
+  description: nonEmptyString,
+  startDate: isoDateString,
+  endDate: isoDateString,
+  lifecycleState: codeId,
+  projectType: codeId,
 });
 
 export type UpsertProject = z.infer<typeof upsertProjectSchema>;
 
 export const periodSchema = z.object({
-  startDate: z.string().regex(isoDateStringRegex),
-  endDate: z.string().regex(isoDateStringRegex),
+  startDate: isoDateString,
+  endDate: isoDateString,
 });
 
 export type Period = z.infer<typeof periodSchema>;

--- a/shared/src/utils.ts
+++ b/shared/src/utils.ts
@@ -69,5 +69,3 @@ export async function retry<T>(
 export async function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
-
-export const isoDateStringRegex = /\d{4}-\d{2}-\d{2}/;


### PR DESCRIPTION
- Add `HankeTyyppi` and `Lautakunta` codes.
- Allow entering `projectType` for project from the codeset
- Projects can be searched with the type
- Project search includes latest `Lautakunta` codes but does not yet search on them since those are not implemented in the datamodel
- FormField now passes the id to form component for better labeling for inputs
- Playwright test simplifying using the form labels