### PR TITLE
Added session expiration detection and renewal

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -22,6 +22,7 @@ autolabeler:
   - label: 'chore'
     branch:
       - '/chore\/.+/'
+      - '/dependabot\/.+/'
 version-resolver:
   major:
     labels:
@@ -29,9 +30,13 @@ version-resolver:
   minor:
     labels:
       - 'minor'
+      - 'feature'
   patch:
     labels:
       - 'patch'
+      - 'fix'
+      - 'chore'
+      - 'infra'
   default: patch
 template: |
   ## Changes

--- a/backend/src/router/index.ts
+++ b/backend/src/router/index.ts
@@ -9,6 +9,8 @@ import { createProjectObjectRouter } from '@backend/router/projectObject';
 
 import { User } from '@shared/schema/user';
 
+import { createSessionRouter } from './session';
+
 export function createContext({ req, res }: CreateFastifyContextOptions) {
   // FIXME: user is serialized as string, but PassportUser is an object, need to
   // check where the type goes wrong
@@ -31,6 +33,7 @@ export const appRouter = t.router({
   project: createProjectRouter(t),
   projectObject: createProjectObjectRouter(t),
   code: createCodeRouter(t),
+  session: createSessionRouter(t),
 });
 
 export type TRPC = typeof t;

--- a/backend/src/router/project.ts
+++ b/backend/src/router/project.ts
@@ -149,12 +149,14 @@ function getFilterFragment(input: z.infer<typeof projectSearchSchema>) {
       AND ${timePeriodFragment(input)}
       AND ${
         input.lifecycleStates && input.lifecycleStates?.length > 0
-          ? sql.fragment`(lifecycle_state).id = ANY(${sql.array(input.lifecycleStates, 'text')})`
+          ? sql.fragment`(lifecycle_state).id = ANY(${sql.array(input.lifecycleStates, 'text')})
+          `
           : sql.fragment`true`
       }
       AND ${
         input.projectTypes && input.projectTypes?.length > 0
-          ? sql.fragment`(project_type).id = ANY(${sql.array(input.projectTypes, 'text')})`
+          ? sql.fragment`(project_type).id = ANY(${sql.array(input.projectTypes, 'text')})
+          `
           : sql.fragment`true`
       }
       ${orderByFragment(input)}

--- a/backend/src/router/session.ts
+++ b/backend/src/router/session.ts
@@ -1,0 +1,9 @@
+import { TRPC } from '@backend/router';
+
+export const createSessionRouter = (t: TRPC) =>
+  t.router({
+    // Session check procedure - returns OK when the session check in pre-validation is passed
+    check: t.procedure.query(async () => {
+      return { sessionOk: true };
+    }),
+  });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,7 +20,9 @@ import { SapDebugView } from '@frontend/views/SapDebug';
 import { Settings } from '@frontend/views/Settings';
 
 import { trpc } from './client';
-import { authAtom, getUserAtom } from './stores/auth';
+import { authAtom, getUserAtom, sessionExpiredAtom } from './stores/auth';
+import { useTranslations } from './stores/lang';
+import { SessionRenewed } from './views/SessionRenewed';
 
 const UserLoader = () => {
   const user = useAtomValue(getUserAtom);
@@ -42,24 +44,43 @@ const router = createBrowserRouter(
       <Route path="saptest/:sapProjectId" element={<SapDebugView />} />
       <Route path="profiili" element={<Profile />} />
       <Route path="asetukset" element={<Settings />} />
+      <Route path="session-renewed" element={<SessionRenewed />} />
       <Route path="*" element={<NotFound />} />
     </Route>
   )
 );
 
 export function App() {
+  const tr = useTranslations();
+  const setSessionExpired = useSetAtom(sessionExpiredAtom);
   const [queryClient] = useState(
     () => new QueryClient({ defaultOptions: { queries: { retry: false } } })
   );
   const [trpcClient] = useState(() =>
     trpc.createClient({
-      links: [httpLink({ url: '/trpc' })],
+      links: [
+        httpLink({
+          url: '/trpc',
+          // Override fetch function to intercept all TRPC response status codes for detecting expired sessions
+          async fetch(url, options) {
+            const result = await fetch(url, { ...options });
+            if (result.status === 401) {
+              // Any 401 error in TRPC responses -> session has been expired
+              setSessionExpired(true);
+            } else {
+              // Any non-401 status -> session is OK
+              setSessionExpired(false);
+            }
+            return result;
+          },
+        }),
+      ],
       transformer: SuperJSON,
     })
   );
 
   return (
-    <Suspense fallback={<p>Ladataan...</p>}>
+    <Suspense fallback={<p>{tr('loading')}</p>}>
       <UserLoader />
       {useAtomValue(authAtom) && (
         <trpc.Provider client={trpcClient} queryClient={queryClient}>

--- a/frontend/src/Layout.tsx
+++ b/frontend/src/Layout.tsx
@@ -13,13 +13,14 @@ import {
   Typography,
   createTheme,
 } from '@mui/material';
-import { useAtom } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 import { Link, Outlet } from 'react-router-dom';
 
 import { useTranslations } from '@frontend/stores/lang';
 
+import { SessionExpiredWarning } from './SessionExpiredWarning';
 import NotificationList from './services/notification';
-import { authAtom } from './stores/auth';
+import { authAtom, sessionExpiredAtom } from './stores/auth';
 
 const theme = createTheme({
   palette: {
@@ -113,10 +114,17 @@ function Navbar() {
 }
 
 export function Layout() {
+  const sessionExpired = useAtomValue(sessionExpiredAtom);
+
   const mainLayoutStyle = css`
     height: 100vh;
     display: flex;
     flex-direction: column;
+    ${sessionExpired &&
+    css`
+      pointer-events: none;
+      user-select: none;
+    `}
   `;
 
   const mainContentStyle = css`
@@ -135,6 +143,7 @@ export function Layout() {
           <Box css={mainContentStyle}>
             <Outlet />
           </Box>
+          <SessionExpiredWarning />
         </ThemeProvider>
       </Box>
     </>

--- a/frontend/src/SessionExpiredWarning.tsx
+++ b/frontend/src/SessionExpiredWarning.tsx
@@ -1,0 +1,67 @@
+import { Box, Button, Drawer, Typography, css } from '@mui/material';
+import { useAtom } from 'jotai';
+import { useEffect } from 'react';
+
+import { trpc } from '@frontend/client';
+
+import { sessionExpiredAtom } from './stores/auth';
+import { useTranslations } from './stores/lang';
+
+const pingIntervalTimeout = 60 * 1000;
+
+export function SessionExpiredWarning() {
+  const [sessionExpired, setSessionExpired] = useAtom(sessionExpiredAtom);
+  const sessionCheck = trpc.session.check.useQuery();
+
+  const tr = useTranslations();
+
+  // Set up the polling to catch expired sessions automatically
+  useEffect(() => {
+    // Set up an interval
+    const pingInterval = setInterval(() => {
+      sessionCheck.refetch();
+    }, pingIntervalTimeout);
+
+    // Clean up: clear the ping interval
+    return () => {
+      clearInterval(pingInterval);
+    };
+  }, []);
+
+  function sessionRenewedListener(event: MessageEvent) {
+    if (event.data === 'session-renewed') {
+      // The opened login window was closed with a successful login -> session is not expired anymore
+      window.removeEventListener('message', sessionRenewedListener);
+      setSessionExpired(false);
+    }
+  }
+
+  return (
+    <Drawer
+      open={sessionExpired}
+      anchor="top"
+      ModalProps={{ slotProps: { backdrop: { style: { backdropFilter: 'grayscale(0.8)' } } } }}
+    >
+      <Box
+        css={css`
+          display: flex;
+          flex-direction: row;
+          padding: 10px;
+          align-items: center;
+          gap: 10px;
+        `}
+      >
+        <Typography>{tr('sessionExpiredWarning.infoText')}</Typography>
+        <Button
+          variant="contained"
+          onClick={() => {
+            window.open(`/api/v1/auth/login?redirect=${encodeURIComponent('/session-renewed')}`);
+            window.addEventListener('message', sessionRenewedListener);
+          }}
+        >
+          {tr('sessionExpiredWarning.buttonText')}
+        </Button>
+      </Box>
+    </Drawer>
+  );
+}

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -4,10 +4,15 @@ import { User } from '@shared/schema/user';
 
 export const authAtom = atom<User | null>(null);
 
+export const sessionExpiredAtom = atom<boolean>(false);
+
 async function getUser() {
   const resp = await fetch('/api/v1/auth/user');
   if (resp.status === 401) {
-    window.location.href = '/api/v1/auth/login';
+    // Pass the current location as the redirect parameter
+    window.location.href = `/api/v1/auth/login?redirect=${encodeURIComponent(
+      window.location.pathname
+    )}`;
   }
   return (await resp.json()) as User;
 }

--- a/frontend/src/stores/lang/en.json
+++ b/frontend/src/stores/lang/en.json
@@ -1,6 +1,8 @@
 {
   "language": "English",
   "loading": "Loading...",
+  "notFound.title": "Not found",
+  "notFound.text": "This page does not exist. Please check the address and reload the page.",
   "unknownError": "Unknown error",
   "date.format": "DD/MM/YYYY",
   "date.format.placeholder": "DD/MM/YYYY",
@@ -139,5 +141,9 @@
   "projectObject.heightLabel": "Rajaus pystysuunnassa",
   "projectObject.heightTooltip": "Syötä kohteen rajaus pystysuunnassa",
   "projectObjectForm.createBtnLabel": "Luo kohde",
-  "projectObjectForm.saveBtnLabel": "Tallenna"
+  "projectObjectForm.saveBtnLabel": "Tallenna",
+  "sessionExpiredWarning.infoText": "Your session is expired. To keep your unsaved changes, please renew the session.",
+  "sessionExpiredWarning.buttonText": "Renew session",
+  "sessionRenewed.title": "Session is renewed",
+  "sessionRenewed.text": "You can now close this tab or navigate to another page."
 }

--- a/frontend/src/stores/lang/fi.json
+++ b/frontend/src/stores/lang/fi.json
@@ -1,6 +1,8 @@
 {
   "language": "suomi",
   "loading": "Ladataan...",
+  "notFound.title": "Sivua ei löytynyt",
+  "notFound.text": "Tätä sivua ei ole olemassa. Tarkista osoite ja yritä ladata sivu uudestaan.",
   "unknownError": "Tunnistamaton virhe",
   "date.format": "D.M.YYYY",
   "date.format.placeholder": "pp.kk.vvvv",
@@ -139,5 +141,9 @@
   "projectObject.notifyGeometryUpdateTitle": "Kohteen sijainti päivitetty",
   "projectObject.notifyGeometryUpdateFailedTitle": "Virhe tallentaessa kohteen sijaintia",
   "projectObjectForm.createBtnLabel": "Luo kohde",
-  "projectObjectForm.saveBtnLabel": "Tallenna"
+  "projectObjectForm.saveBtnLabel": "Tallenna",
+  "sessionExpiredWarning.infoText": "Istuntosi on vanhentunut. Jatkaaksesi keskeneräisiä töitäsi, uusi istunto.",
+  "sessionExpiredWarning.buttonText": "Uusi istunto",
+  "sessionRenewed.title": "Istunto on uusittu",
+  "sessionRenewed.text": "Voit nyt sulkea tämän välilehden tai siirtyä haluamallesi sivulle valikosta."
 }

--- a/frontend/src/stores/lang/index.tsx
+++ b/frontend/src/stores/lang/index.tsx
@@ -14,7 +14,7 @@ export type TranslationKey = keyof typeof translations[Language];
 export function useTranslations() {
   const value = useAtomValue(trAtom);
   return function tr(key: TranslationKey) {
-    return value[key] ?? <span style={{ background: 'yellow' }}>{key}</span>;
+    return value[key] ?? <span style={{ background: 'yellow', color: 'black' }}>{key}</span>;
   };
 }
 

--- a/frontend/src/views/NotFound.tsx
+++ b/frontend/src/views/NotFound.tsx
@@ -1,11 +1,13 @@
 import { Box, Typography } from '@mui/material';
-import React from 'react';
+
+import { useTranslations } from '@frontend/stores/lang';
 
 export function NotFound() {
+  const tr = useTranslations();
   return (
     <Box>
-      <Typography variant="h4">Not found</Typography>
-      <Typography variant="body1">This page does not exist</Typography>
+      <Typography variant="h4">{tr('notFound.title')}</Typography>
+      <Typography variant="body1">{tr('notFound.text')}</Typography>
     </Box>
   );
 }

--- a/frontend/src/views/Project/Project.tsx
+++ b/frontend/src/views/Project/Project.tsx
@@ -3,9 +3,6 @@ import { AccountTree, Euro, ListAlt, Map } from '@mui/icons-material';
 import { Box, Breadcrumbs, Chip, Paper, Tab, Tabs, Typography } from '@mui/material';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
-import Fill from 'ol/style/Fill';
-import Stroke from 'ol/style/Stroke';
-import Style from 'ol/style/Style';
 import { useMemo } from 'react';
 import { useParams } from 'react-router';
 import { Link } from 'react-router-dom';
@@ -136,7 +133,7 @@ export function Project() {
     return <Typography>{tr('loading')}</Typography>;
   }
 
-  if (project.isError) {
+  if (project.isError && project.error.data?.code !== 'UNAUTHORIZED') {
     return (
       <ErrorPage
         severity="warning"

--- a/frontend/src/views/ProjectObject/ProjectObject.tsx
+++ b/frontend/src/views/ProjectObject/ProjectObject.tsx
@@ -108,8 +108,17 @@ export function ProjectObject() {
     return <Typography>{tr('loading')}</Typography>;
   }
 
-  if (projectObject?.isError) {
-    return <ErrorPage severity="warning" message={tr('projectObject.notFound')} />;
+  if (projectObject.isError && projectObject.error.data?.code !== 'UNAUTHORIZED') {
+    return (
+      <ErrorPage
+        severity="warning"
+        message={
+          projectObject.error.data?.code === 'NOT_FOUND'
+            ? tr('projectObject.notFound')
+            : tr('unknownError')
+        }
+      />
+    );
   }
 
   return (

--- a/frontend/src/views/SessionRenewed.tsx
+++ b/frontend/src/views/SessionRenewed.tsx
@@ -1,0 +1,24 @@
+import { Box, Typography } from '@mui/material';
+import { useEffect } from 'react';
+
+import { useTranslations } from '@frontend/stores/lang';
+
+export function SessionRenewed() {
+  const tr = useTranslations();
+
+  // On mount, if the page was opened via session expired warning, close the page and notify the opener
+  useEffect(() => {
+    if (!window.opener) {
+      return;
+    }
+    window.opener?.postMessage('session-renewed');
+    window.close();
+  }, []);
+
+  return (
+    <Box>
+      <Typography variant="h4">{tr('sessionRenewed.title')}</Typography>
+      <Typography variant="body1">{tr('sessionRenewed.text')}</Typography>
+    </Box>
+  );
+}


### PR DESCRIPTION
- Intercept all HTTP errors from TRPC and show a warning drawer when any request returns 401
- Added 1 minute polling interval to check if the session has expired
- For session renewal, added a button to open a new window that closes after the login is complete
- Added redirect when entering any page without a valid session