### PR TITLE
Added extra hosts to production image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -152,6 +152,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
+          add-hosts: ${{ secrets.IMAGE_EXTRA_HOSTS }}
           tags: ${{ env.IMAGE_NAME }}:${{ env.ENV_NAME }}
           cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:latest
           cache-to: type=inline


### PR DESCRIPTION
Extra hosts are stored and read by CI from secrets. The accepted format for each entry is `host:ip` and multiple entries can be listed as a comma or newline delimited string.

https://github.com/docker/build-push-action#inputs