### PR TITLE
Project object SAP WBS selection

### DIFF
--- a/backend/db_migrations/0024_projectobject_sap-id-link.sql
+++ b/backend/db_migrations/0024_projectobject_sap-id-link.sql
@@ -1,0 +1,1 @@
+ALTER TABLE project_object ADD COLUMN sap_wbs_id TEXT;

--- a/backend/src/router/projectObject.ts
+++ b/backend/src/router/projectObject.ts
@@ -29,6 +29,7 @@ const projectObjectFragment = sql.fragment`
      person_responsible AS "personResponsible",
      start_date AS "startDate",
      end_date AS "endDate",
+     sap_wbs_id AS "sapWBSId",
      ST_AsGeoJSON(ST_CollectionExtract(geom)) AS geom,
      (landownership).id AS "landownership",
      (location_on_property).id AS "locationOnProperty",
@@ -64,6 +65,7 @@ async function upsertProjectObject(projectObject: UpsertProjectObject, userId: s
     person_responsible: projectObject.personResponsible,
     start_date: projectObject.startDate,
     end_date: projectObject.endDate,
+    sap_wbs_id: projectObject.sapWBSId ?? null,
     landownership: codeIdFragment('KohteenMaanomistusLaji', projectObject.landownership),
     location_on_property: codeIdFragment(
       'KohteenSuhdePeruskiinteistoon',

--- a/backend/src/router/sap.ts
+++ b/backend/src/router/sap.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { getSapActuals, getSapProject } from '@backend/components/sap/dataImport';
+import { getPool, sql } from '@backend/db';
 
 import { TRPC } from '.';
 
@@ -11,9 +12,31 @@ export const createSapRouter = (t: TRPC) =>
       .mutation(async ({ input }) => {
         return getSapProject(input.projectId);
       }),
+
     getSapActuals: t.procedure
       .input(z.object({ projectId: z.string(), year: z.string() }))
       .mutation(async ({ input }) => {
         return getSapActuals(input.projectId, input.year);
+      }),
+
+    getWBSByProjectId: t.procedure
+      .input(z.object({ projectId: z.string() }))
+      .query(async ({ input }) => {
+        const result = await getPool().maybeOne(sql.type(z.object({ sapProjectId: z.string() }))`
+          SELECT sap_project_id AS "sapProjectId"
+          FROM app.project
+          WHERE id = ${input.projectId}
+        `);
+        if (result?.sapProjectId) {
+          const sapProject = await getSapProject(result?.sapProjectId);
+          return sapProject?.wbs.map((wbs) => {
+            return {
+              wbsId: wbs.wbsId,
+              shortDescription: wbs.shortDescription,
+            };
+          });
+        } else {
+          return null;
+        }
       }),
   });

--- a/frontend/src/stores/lang/en.json
+++ b/frontend/src/stores/lang/en.json
@@ -129,6 +129,8 @@
   "projectObject.startDateTooltip": "Valitse kohteelle aloituspäivämäärä",
   "projectObject.endDateLabel": "Loppupäivämäärä",
   "projectObject.endDateTooltip": "Valitse kohteen lopetuspäivämäärä",
+  "projectObject.sapWBSIdLabel": "SAP-rakenneosa",
+  "projectObject.sapWBSIdTooltip": "Valitse SAP-rakenneosa",
   "projectObject.landownershipLabel": "Maanomistuslaji",
   "projectObject.landownershipTooltip": "Valitse kohteen maanomistuslaji",
   "projectObject.locationOnPropertyLabel": "Kohteen suhde peruskiinteistöön",
@@ -145,5 +147,6 @@
   "sessionExpiredWarning.infoText": "Your session is expired. To keep your unsaved changes, please renew the session.",
   "sessionExpiredWarning.buttonText": "Renew session",
   "sessionRenewed.title": "Session is renewed",
-  "sessionRenewed.text": "You can now close this tab or navigate to another page."
+  "sessionRenewed.text": "You can now close this tab or navigate to another page.",
+  "sapWBSSelect.noOptions": "SAP-rakenneosia ei löytynyt"
 }

--- a/frontend/src/stores/lang/fi.json
+++ b/frontend/src/stores/lang/fi.json
@@ -129,6 +129,8 @@
   "projectObject.startDateTooltip": "Valitse kohteelle aloituspäivämäärä",
   "projectObject.endDateLabel": "Loppupäivämäärä",
   "projectObject.endDateTooltip": "Valitse kohteen lopetuspäivämäärä",
+  "projectObject.sapWBSIdLabel": "SAP-rakenneosa",
+  "projectObject.sapWBSIdTooltip": "Valitse SAP-rakenneosa",
   "projectObject.landownershipLabel": "Maanomistuslaji",
   "projectObject.landownershipTooltip": "Valitse kohteen maanomistuslaji",
   "projectObject.locationOnPropertyLabel": "Kohteen suhde peruskiinteistöön",
@@ -145,5 +147,6 @@
   "sessionExpiredWarning.infoText": "Istuntosi on vanhentunut. Jatkaaksesi keskeneräisiä töitäsi, uusi istunto.",
   "sessionExpiredWarning.buttonText": "Uusi istunto",
   "sessionRenewed.title": "Istunto on uusittu",
-  "sessionRenewed.text": "Voit nyt sulkea tämän välilehden tai siirtyä haluamallesi sivulle valikosta."
+  "sessionRenewed.text": "Voit nyt sulkea tämän välilehden tai siirtyä haluamallesi sivulle valikosta.",
+  "sapWBSSelect.noOptions": "SAP-rakenneosia ei löytynyt"
 }

--- a/frontend/src/views/ProjectObject/ProjectObjectForm.tsx
+++ b/frontend/src/views/ProjectObject/ProjectObjectForm.tsx
@@ -14,6 +14,7 @@ import { FormDatePicker, FormField } from '@frontend/components/forms';
 import { CodeSelect } from '@frontend/components/forms/CodeSelect';
 import { useNotifications } from '@frontend/services/notification';
 import { useTranslations } from '@frontend/stores/lang';
+import { SapWBSSelect } from '@frontend/views/ProjectObject/SapWBSSelect';
 
 import { UpsertProjectObject, upsertProjectObjectSchema } from '@shared/schema/projectObject';
 
@@ -243,6 +244,16 @@ export function ProjectObjectForm(props: Props) {
             />
           )}
         />
+
+        <FormField
+          formField="sapWBSId"
+          label={tr('projectObject.sapWBSIdLabel')}
+          tooltip={tr('projectObject.sapWBSIdTooltip')}
+          component={(field) => (
+            <SapWBSSelect projectId={props.projectId} readonlyProps={readonlyProps} field={field} />
+          )}
+        />
+
         <FormField
           formField="landownership"
           label={tr('projectObject.landownershipLabel')}

--- a/frontend/src/views/ProjectObject/SapWBSSelect.tsx
+++ b/frontend/src/views/ProjectObject/SapWBSSelect.tsx
@@ -1,0 +1,59 @@
+import { FileDownload } from '@mui/icons-material';
+import { Autocomplete, CircularProgress, TextField } from '@mui/material';
+import { ControllerRenderProps, FieldValues } from 'react-hook-form';
+
+import { trpc } from '@frontend/client';
+import { useTranslations } from '@frontend/stores/lang';
+
+interface Props {
+  projectId: string;
+  readonlyProps?: {
+    hiddenLabel?: boolean;
+    variant?: 'filled';
+    InputProps?: {
+      readOnly: boolean;
+    };
+  };
+  field: ControllerRenderProps<FieldValues, string> & { id?: string };
+}
+
+export function SapWBSSelect(props: Props) {
+  const tr = useTranslations();
+  const wbsProjects = trpc.sap.getWBSByProjectId.useQuery({ projectId: props.projectId });
+
+  const options = wbsProjects.data?.map((wbs) => wbs.wbsId);
+
+  return (
+    <Autocomplete
+      autoHighlight
+      size="small"
+      ref={props.field.ref}
+      value={props.field.value}
+      onChange={(_, value) => props.field.onChange(value)}
+      options={options ?? []}
+      noOptionsText={tr('sapWBSSelect.noOptions')}
+      getOptionLabel={(id) => {
+        const wbs = wbsProjects.data?.find((wbs) => wbs.wbsId === id);
+        return `${wbs?.shortDescription} (${wbs?.wbsId})`;
+      }}
+      renderInput={(params) => {
+        const { InputProps, ...restParams } = params;
+        return (
+          <TextField
+            {...restParams}
+            InputProps={{
+              ...InputProps,
+              endAdornment: wbsProjects.isLoading ? (
+                <CircularProgress color="inherit" size={20} />
+              ) : (
+                InputProps.endAdornment
+              ),
+            }}
+            {...props.readonlyProps}
+            {...props.field}
+          />
+        );
+      }}
+    />
+  );
+}

--- a/shared/src/schema/projectObject.ts
+++ b/shared/src/schema/projectObject.ts
@@ -15,6 +15,7 @@ export const upsertProjectObjectSchema = z.object({
   personResponsible: z.string(),
   startDate: isoDateString,
   endDate: isoDateString,
+  sapWBSId: nonEmptyString.optional().nullable(),
   landownership: codeId.optional().nullable(),
   locationOnProperty: codeId.optional().nullable(),
   height: z.coerce.number().optional().nullable(),


### PR DESCRIPTION
- Add `sap_wbs_id` field to project object
- Add API to get WBS list based on the Hanna project ID (using `sap_project_id` of that project)
- Add autocomplete component with resolved list of WBS as options to project object form

![Screen Recording 2023-01-25 at 16 46 09](https://user-images.githubusercontent.com/5307970/214594444-1fdccffa-f22b-411c-bcb4-e137914f6b71.gif)
