### PR TITLE
[SAP] fix WTGBTR xs:fractionDigits handling

### DIFF
--- a/backend/src/components/sap/transform.ts
+++ b/backend/src/components/sap/transform.ts
@@ -146,7 +146,8 @@ function currencyInSubunit(amount: string, separator = '.') {
   const [whole, fraction] = amount.split(separator);
   let result = parseInt(whole, 10) * 100;
   if (fraction) {
-    result += parseInt(fraction, 10);
+    // normalize fraction to 2 digits
+    result += parseInt(fraction.padEnd(2, '0'), 10);
   }
   return result;
 }


### PR DESCRIPTION
Normalize fractional amounts to 2 digits _with trailing zeros_. (e.g. `'1720.5'` => `'1720.50'`)

Checked `xs:fractionDigits` spec which states the following:
https://www.oreilly.com/library/view/xml-schema/0596002521/re24.html

> This facet constrains the value space, which means that the number of fractional digits is checked after the value is transformed to its canonical form, and the trailing zeros are removed. 