### PR TITLE
Add audit event system

### DIFF
--- a/backend/db_migrations/0038_audit_event.sql
+++ b/backend/db_migrations/0038_audit_event.sql
@@ -1,0 +1,26 @@
+DROP TRIGGER project_history_trigger ON project;
+DROP FUNCTION project_history_trigger();
+
+DROP TRIGGER project_object_history_trigger ON project_object;
+DROP FUNCTION project_object_history_trigger();
+
+DROP TRIGGER task_history_trigger ON task;
+DROP FUNCTION task_history_trigger();
+
+DROP TRIGGER contractor_company_history_entry_trigger ON contractor_company;
+DROP TRIGGER contractor_history_entry_trigger ON contractor;
+DROP FUNCTION history_entry_trigger();
+
+ALTER TABLE project_history RENAME TO _deprecated_project_history;
+ALTER TABLE project_object_history RENAME TO _deprecated_project_object_history;
+ALTER TABLE task_history RENAME TO _deprecated_task_history;
+ALTER TABLE history_entry RENAME TO _deprecated_history_entry;
+
+CREATE TABLE audit_event (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_type TEXT NOT NULL,
+  event_data JSONB NOT NULL,
+  event_user TEXT NOT NULL REFERENCES "user"(id) ON DELETE RESTRICT ON UPDATE CASCADE,
+  event_timestamp TIMESTAMPTZ NOT NULL DEFAULT now(),
+  event_metadata JSONB
+);

--- a/backend/src/components/audit.ts
+++ b/backend/src/components/audit.ts
@@ -1,0 +1,19 @@
+import stringify from 'fast-json-stable-stringify';
+import { DatabaseTransactionConnection } from 'slonik';
+
+import { sql } from '@backend/db';
+
+import { User } from '@shared/schema/user';
+
+interface AuditEvent {
+  eventType: string;
+  eventData: object;
+  eventUser: User['id'];
+}
+
+export function addAuditEvent(tx: DatabaseTransactionConnection, entry: AuditEvent) {
+  return tx.query(sql.untyped`
+    INSERT INTO app.audit_event (event_type, event_data, event_user, event_timestamp)
+    VALUES (${entry.eventType}, ${stringify(entry.eventData)}::jsonb, ${entry.eventUser}, now())
+  `);
+}

--- a/backend/src/components/project/detailplan.ts
+++ b/backend/src/components/project/detailplan.ts
@@ -2,6 +2,7 @@ import { TRPCError } from '@trpc/server';
 import { DatabaseTransactionConnection } from 'slonik';
 import { z } from 'zod';
 
+import { addAuditEvent } from '@backend/components/audit';
 import { baseProjectUpsert } from '@backend/components/project/base';
 import { getPool, sql } from '@backend/db';
 import { codeIdFragment } from '@backend/router/code';
@@ -62,6 +63,11 @@ export async function getProject(id: string, tx?: DatabaseTransactionConnection)
 export async function projectUpsert(project: DetailplanProject, user: User) {
   return await getPool().transaction(async (tx) => {
     const id = await baseProjectUpsert(tx, project, user);
+    await addAuditEvent(tx, {
+      eventType: 'projectDetailplan.upsertProject',
+      eventData: project,
+      eventUser: user.id,
+    });
 
     const data = {
       id,

--- a/backend/src/router/project/base.ts
+++ b/backend/src/router/project/base.ts
@@ -38,13 +38,13 @@ export const createProjectRouter = (t: TRPC) =>
       return getRelatedProjects(id);
     }),
 
-    delete: t.procedure.input(projectIdSchema).mutation(async ({ input }) => {
+    delete: t.procedure.input(projectIdSchema).mutation(async ({ input, ctx }) => {
       const { id } = input;
-      return deleteProject(id);
+      return deleteProject(id, ctx.user.id);
     }),
 
-    updateGeometry: t.procedure.input(updateGeometrySchema).mutation(async ({ input }) => {
-      return updateProjectGeometry(input);
+    updateGeometry: t.procedure.input(updateGeometrySchema).mutation(async ({ input, ctx }) => {
+      return updateProjectGeometry(input, ctx.user);
     }),
 
     getCostEstimates: t.procedure.input(getCostEstimatesInputSchema).query(async ({ input }) => {
@@ -53,18 +53,18 @@ export const createProjectRouter = (t: TRPC) =>
 
     updateCostEstimates: t.procedure
       .input(updateCostEstimatesInputSchema)
-      .mutation(async ({ input }) => {
-        return updateCostEstimates(input);
+      .mutation(async ({ input, ctx }) => {
+        return updateCostEstimates(input, ctx.user);
       }),
 
-    updateRelations: t.procedure.input(relationsSchema).mutation(async ({ input }) => {
+    updateRelations: t.procedure.input(relationsSchema).mutation(async ({ input, ctx }) => {
       const { subjectProjectId, objectProjectId, relation } = input;
-      return await addProjectRelation(subjectProjectId, objectProjectId, relation);
+      return await addProjectRelation(subjectProjectId, objectProjectId, relation, ctx.user);
     }),
 
-    remoteRelation: t.procedure.input(relationsSchema).mutation(async ({ input }) => {
+    removeRelation: t.procedure.input(relationsSchema).mutation(async ({ input, ctx }) => {
       const { subjectProjectId: projectId, objectProjectId: targetProjectId, relation } = input;
-      return await removeProjectRelation(projectId, targetProjectId, relation);
+      return await removeProjectRelation(projectId, targetProjectId, relation, ctx.user);
     }),
 
     startReportJob: t.procedure.input(projectSearchSchema).query(async ({ input }) => {

--- a/frontend/src/views/Project/ProjectRelations.tsx
+++ b/frontend/src/views/Project/ProjectRelations.tsx
@@ -44,7 +44,7 @@ export function ProjectRelations({ projectId }: Props) {
     },
   });
 
-  const deleteRelation = trpc.project.remoteRelation.useMutation({
+  const deleteRelation = trpc.project.removeRelation.useMutation({
     onSuccess: () => {
       relations.refetch();
       notify({


### PR DESCRIPTION
Deprecate DB trigger-based history tables and triggers. Add audit event system that is used programmatically in the backend. Audit events are now generated for every side-effecting API.

History tables did not cover all the use cases such as modifying cost estimates or project relations. Also, it really worked only when there was a simple 1:1 mapping from object to a database table.

Now operations are audit logged on the TRPC endpoint level which is more meaningful (e.g. delete operation called with specific payload at specified time by specific user) vs. trying to use triggers to maintain database table-level history tables when domain data object might be stored on multiple tables etc.