### PR TITLE
Added detailplan ID to universal text search

### DIFF
--- a/backend/db_migrations/0040_detailplan-id-search.sql
+++ b/backend/db_migrations/0040_detailplan-id-search.sql
@@ -1,0 +1,11 @@
+ALTER TABLE app.project_detailplan
+ADD COLUMN tsv tsvector GENERATED ALWAYS AS (
+  setweight(
+    to_tsvector(
+      'simple',
+      coalesce(detailplan_id::text, '')
+    ),
+    'A'
+  )
+) STORED;
+CREATE INDEX ON app.project_detailplan USING gin(tsv);


### PR DESCRIPTION
- Added a generated `tsv` column to `project_detailplan`
  - Only contains `detailplan_id` for now, but can be easily expanded to contain other columns later
- Modified universal text search to concatenate "subtype table" `tsv`s before querying