### PR TITLE
Catch errors in form validations

### DIFF
--- a/frontend/src/views/DetailplanProject/DetailplanProjectForm.tsx
+++ b/frontend/src/views/DetailplanProject/DetailplanProjectForm.tsx
@@ -93,7 +93,9 @@ export function DetailplanProjectForm(props: Props) {
     ) {
       const fields = options.names ?? [];
       const isFormValidation = fields && fields.length > 1;
-      const serverErrors = isFormValidation ? detailplanProject.upsertValidate.fetch(values) : null;
+      const serverErrors = isFormValidation
+        ? detailplanProject.upsertValidate.fetch(values).catch(() => null)
+        : null;
       const shapeErrors = schemaValidation(values, context, options);
       const errors = await Promise.all([serverErrors, shapeErrors]);
       return {

--- a/frontend/src/views/Project/InvestmentProjectForm.tsx
+++ b/frontend/src/views/Project/InvestmentProjectForm.tsx
@@ -78,7 +78,9 @@ export function InvestmentProjectForm(props: InvestmentProjectFormProps) {
     ) {
       const fields = options.names ?? [];
       const isFormValidation = fields && fields.length > 1;
-      const serverErrors = isFormValidation ? investmentProject.upsertValidate.fetch(values) : null;
+      const serverErrors = isFormValidation
+        ? investmentProject.upsertValidate.fetch(values).catch(() => null)
+        : null;
       const shapeErrors = schemaValidation(values, context, options);
       const errors = await Promise.all([serverErrors, shapeErrors]);
       return {


### PR DESCRIPTION
If react-hook-form's `resolver` throws an error, the form hangs indefinitely. Because of this, we need to ignore any server-side errors and fail silently. In case of upsert procedures, each project gets validated server-side anyway.