### PR TITLE
Added proxy route for protected Georaster layers

### DIFF
--- a/backend/.template.env
+++ b/backend/.template.env
@@ -47,3 +47,8 @@ EMAIL_AUTH_METHOD=none
 # Detailplan notification
 DETAILPLAN_NOTIFICATION_RECIPIENTS=recipient1@email.com,recipient2@email.com
 DETAILPLAN_NOTIFICATION_SIGNATURE_FROM=Hanna
+
+# Georaster proxy
+PROXY_GEORASTER_UPSTREAM=<Georaster Geoserver URL>
+PROXY_GEORASTER_USERNAME=<Username>
+PROXY_GEORASTER_PASSWORD=<Password>

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,6 +12,7 @@
         "@fastify/compress": "^6.2.1",
         "@fastify/cookie": "^8.3.0",
         "@fastify/formbody": "^7.4.0",
+        "@fastify/http-proxy": "^9.1.0",
         "@fastify/passport": "^2.3.0",
         "@fastify/sensible": "^5.2.0",
         "@fastify/session": "^10.3.0",
@@ -2246,6 +2247,16 @@
         "fastify-plugin": "^4.0.0"
       }
     },
+    "node_modules/@fastify/http-proxy": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/http-proxy/-/http-proxy-9.1.0.tgz",
+      "integrity": "sha512-vgHCTDKOqLB437zQJiLWFFnsrYfFZ6Lfwu/xXQoKqRUKIPDt+xG6LBRtf8s5MNqfFVoTE7kw1U/0qdRGDsMp4Q==",
+      "dependencies": {
+        "@fastify/reply-from": "^9.0.0",
+        "fastify-plugin": "^4.5.0",
+        "ws": "^8.4.2"
+      }
+    },
     "node_modules/@fastify/passport": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@fastify/passport/-/passport-2.3.0.tgz",
@@ -2253,6 +2264,28 @@
       "dependencies": {
         "@fastify/flash": "^5.0.0",
         "fastify-plugin": "^4.0.0"
+      }
+    },
+    "node_modules/@fastify/reply-from": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@fastify/reply-from/-/reply-from-9.0.1.tgz",
+      "integrity": "sha512-q9vFNUiXZTY1x8omDPe59os2MYq+3y7KgO/kZoXpZlnud+45Nd8Ot/svEvrUATzjkizIggfS4K8LR9zXDyZZKg==",
+      "dependencies": {
+        "@fastify/error": "^3.0.0",
+        "end-of-stream": "^1.4.4",
+        "fast-querystring": "^1.0.0",
+        "fastify-plugin": "^4.0.0",
+        "pump": "^3.0.0",
+        "tiny-lru": "^10.0.0",
+        "undici": "^5.19.1"
+      }
+    },
+    "node_modules/@fastify/reply-from/node_modules/tiny-lru": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-10.4.1.tgz",
+      "integrity": "sha512-buLIzw7ppqymuO3pt10jHk/6QMeZLbidihMQU+N6sogF6EnBzG0qtDWIHuhw1x3dyNgVL/KTGIZsTK81+yCzLg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@fastify/send": {
@@ -3450,6 +3483,17 @@
       "license": "MIT/X11",
       "engines": {
         "node": ">=0.3.0"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/cac": {
@@ -5110,8 +5154,9 @@
       }
     },
     "node_modules/fastify-plugin": {
-      "version": "4.2.1",
-      "license": "MIT"
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-4.5.0.tgz",
+      "integrity": "sha512-79ak0JxddO0utAXAQ5ccKhvs6vX2MGyHHMMsmZkBANrq3hXc1CHzvNPHOcvTsVMEPl5I+NT+RO4YKMGehOfSIg=="
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -8300,6 +8345,14 @@
       "version": "1.0.1",
       "license": "MIT"
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "license": "MIT",
@@ -8686,6 +8739,17 @@
       },
       "peerDependencies": {
         "underscore": "1.x"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.0.tgz",
+      "integrity": "sha512-fR9RXCc+6Dxav4P9VV/sp5w3eFiSdOjJYsbtWfd4s5L5C4ogyuVpdKIVHeW0vV1MloM65/f7W45nR9ZxwVdyiA==",
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/uri-js": {
@@ -9228,6 +9292,26 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xml-crypto": {
       "version": "3.0.1",
@@ -10019,6 +10103,16 @@
         "fastify-plugin": "^4.0.0"
       }
     },
+    "@fastify/http-proxy": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/http-proxy/-/http-proxy-9.1.0.tgz",
+      "integrity": "sha512-vgHCTDKOqLB437zQJiLWFFnsrYfFZ6Lfwu/xXQoKqRUKIPDt+xG6LBRtf8s5MNqfFVoTE7kw1U/0qdRGDsMp4Q==",
+      "requires": {
+        "@fastify/reply-from": "^9.0.0",
+        "fastify-plugin": "^4.5.0",
+        "ws": "^8.4.2"
+      }
+    },
     "@fastify/passport": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@fastify/passport/-/passport-2.3.0.tgz",
@@ -10026,6 +10120,27 @@
       "requires": {
         "@fastify/flash": "^5.0.0",
         "fastify-plugin": "^4.0.0"
+      }
+    },
+    "@fastify/reply-from": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@fastify/reply-from/-/reply-from-9.0.1.tgz",
+      "integrity": "sha512-q9vFNUiXZTY1x8omDPe59os2MYq+3y7KgO/kZoXpZlnud+45Nd8Ot/svEvrUATzjkizIggfS4K8LR9zXDyZZKg==",
+      "requires": {
+        "@fastify/error": "^3.0.0",
+        "end-of-stream": "^1.4.4",
+        "fast-querystring": "^1.0.0",
+        "fastify-plugin": "^4.0.0",
+        "pump": "^3.0.0",
+        "tiny-lru": "^10.0.0",
+        "undici": "^5.19.1"
+      },
+      "dependencies": {
+        "tiny-lru": {
+          "version": "10.4.1",
+          "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-10.4.1.tgz",
+          "integrity": "sha512-buLIzw7ppqymuO3pt10jHk/6QMeZLbidihMQU+N6sogF6EnBzG0qtDWIHuhw1x3dyNgVL/KTGIZsTK81+yCzLg=="
+        }
       }
     },
     "@fastify/send": {
@@ -10894,6 +11009,14 @@
     },
     "bufferput": {
       "version": "0.1.3"
+    },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "requires": {
+        "streamsearch": "^1.1.0"
+      }
     },
     "cac": {
       "version": "6.7.14",
@@ -12086,7 +12209,9 @@
       }
     },
     "fastify-plugin": {
-      "version": "4.2.1"
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-4.5.0.tgz",
+      "integrity": "sha512-79ak0JxddO0utAXAQ5ccKhvs6vX2MGyHHMMsmZkBANrq3hXc1CHzvNPHOcvTsVMEPl5I+NT+RO4YKMGehOfSIg=="
     },
     "fastq": {
       "version": "1.13.0",
@@ -14348,6 +14473,11 @@
     "stream-shift": {
       "version": "1.0.1"
     },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
+    },
     "string_decoder": {
       "version": "1.3.0",
       "requires": {
@@ -15272,6 +15402,14 @@
       "integrity": "sha512-4OuSOlFNkiVFVc3khkeG112Pdu1gbitMj7t9B9ENb61uFmN70Jq7Iluhi3oflcSgexkKfDdJ5XAJET2gEq6ikA==",
       "requires": {}
     },
+    "undici": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.0.tgz",
+      "integrity": "sha512-fR9RXCc+6Dxav4P9VV/sp5w3eFiSdOjJYsbtWfd4s5L5C4ogyuVpdKIVHeW0vV1MloM65/f7W45nR9ZxwVdyiA==",
+      "requires": {
+        "busboy": "^1.6.0"
+      }
+    },
     "uri-js": {
       "version": "4.4.1",
       "requires": {
@@ -15604,6 +15742,12 @@
     },
     "wrappy": {
       "version": "1.0.2"
+    },
+    "ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "requires": {}
     },
     "xml-crypto": {
       "version": "3.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -53,6 +53,7 @@
     "@fastify/compress": "^6.2.1",
     "@fastify/cookie": "^8.3.0",
     "@fastify/formbody": "^7.4.0",
+    "@fastify/http-proxy": "^9.1.0",
     "@fastify/passport": "^2.3.0",
     "@fastify/sensible": "^5.2.0",
     "@fastify/session": "^10.3.0",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -17,6 +17,7 @@ import { logger } from '@backend/logging';
 import { getClient } from '@backend/oidc';
 import { appRouter, createContext } from '@backend/router';
 
+import { georasterProxy } from './components/proxy/georaster';
 import { initializeTaskQueue } from './components/taskQueue';
 import { setupMailQueue } from './components/taskQueue/mailQueue';
 import { setupReportQueue } from './components/taskQueue/reportQueue';
@@ -70,8 +71,8 @@ async function run() {
   server.register(fastifyCompress);
   server.setNotFoundHandler((req, reply) => {
     const url = req.raw.url;
-    // For not found /api or /trpc routes -> throw a 404 error
-    if (url?.startsWith('/api') || url?.startsWith('/trpc')) {
+    // For not found backend routes -> throw a 404 error
+    if (['/api', '/trpc', '/proxy'].some((prefix) => url?.startsWith(prefix))) {
       throw server.httpErrors.notFound(`${url} not found`);
     }
     // For other routes -> let the frontend handle the client-side routing
@@ -95,6 +96,7 @@ async function run() {
 
   server.register(healthApi, { prefix: '/api/v1' });
   server.register(reportDownloadApi, { prefix: '/api/v1' });
+  server.register(georasterProxy);
 
   const defaultErrorHandler = server.errorHandler;
 

--- a/backend/src/components/proxy/georaster.ts
+++ b/backend/src/components/proxy/georaster.ts
@@ -1,0 +1,27 @@
+import fastifyHttpProxy from '@fastify/http-proxy';
+import { FastifyInstance, FastifyPluginOptions } from 'fastify';
+
+import { env } from '@backend/env';
+
+export function georasterProxy(
+  server: FastifyInstance,
+  _opts: FastifyPluginOptions,
+  done: () => void
+) {
+  server.register(fastifyHttpProxy, {
+    upstream: env.proxy.georaster.upstream,
+    prefix: '/proxy/georaster',
+    replyOptions: {
+      rewriteRequestHeaders: (_request, headers) => {
+        return {
+          ...headers,
+          Authorization: `Basic ${Buffer.from(
+            `${env.proxy.georaster.username}:${env.proxy.georaster.password}`
+          ).toString('base64')}`,
+        };
+      },
+    },
+  });
+
+  done();
+}

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -72,6 +72,13 @@ const schema = z.object({
     notificationRecipients: z.array(z.string()),
     notificationSignatureFrom: z.string(),
   }),
+  proxy: z.object({
+    georaster: z.object({
+      upstream: z.string(),
+      username: z.string(),
+      password: z.string(),
+    }),
+  }),
 });
 
 function getEnv() {
@@ -138,6 +145,13 @@ function getEnv() {
     detailplan: {
       notificationRecipients: process.env.DETAILPLAN_NOTIFICATION_RECIPIENTS?.split(',') ?? [],
       notificationSignatureFrom: process.env.DETAILPLAN_NOTIFICATION_SIGNATURE_FROM,
+    },
+    proxy: {
+      georaster: {
+        upstream: process.env.PROXY_GEORASTER_UPSTREAM,
+        username: process.env.PROXY_GEORASTER_USERNAME,
+        password: process.env.PROXY_GEORASTER_PASSWORD,
+      },
     },
   } as z.infer<typeof schema>);
 }

--- a/e2e/backend.env
+++ b/e2e/backend.env
@@ -46,3 +46,8 @@ EMAIL_AUTH_METHOD=none
 # Detailplan notification
 DETAILPLAN_NOTIFICATION_RECIPIENTS=recipient1@email.com,recipient2@email.com
 DETAILPLAN_NOTIFICATION_SIGNATURE_FROM=Hanna
+
+# Georaster proxy
+PROXY_GEORASTER_UPSTREAM=https://localhost:1443/geoserver
+PROXY_GEORASTER_USERNAME=username
+PROXY_GEORASTER_PASSWORD=password

--- a/frontend/src/components/Map/mapOptions.tsx
+++ b/frontend/src/components/Map/mapOptions.tsx
@@ -97,7 +97,7 @@ export const mapOptions = {
       type: 'base',
       options: {
         protocol: 'wmts',
-        url: 'https://georaster.tampere.fi/geoserver/gwc/service/wmts?service=WMTS',
+        url: '/proxy/georaster/gwc/service/wmts?service=WMTS',
         layer: 'georaster:kantakartta_mml_harmaa_EPSG_3067',
         matrixSet: 'JHS',
         projection: 'EPSG:3067',

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -19,6 +19,7 @@ const serverOptions: CommonServerOptions = {
     '/logout': proxyAddress,
     '/api': proxyAddress,
     '/trpc': proxyAddress,
+    '/proxy': proxyAddress,
   },
 };
 


### PR DESCRIPTION
- Added a new `/proxy/georaster` endpoint for proxying requests to protected Georaster endpoints (requiring credentials)
- Moved `Kantakartta` to use the proxy URL