### PR TITLE
Added detailplan ID to project search result card

### DIFF
--- a/backend/src/components/project/search.ts
+++ b/backend/src/components/project/search.ts
@@ -124,6 +124,7 @@ export function detailplanProjectFragment(input: ProjectSearch) {
   return sql.fragment`
     SELECT
       project_detailplan.id,
+      project_detailplan.detailplan_id AS "detailplanId",
       'detailplanProject' AS "projectType"
     FROM app.project_detailplan
     WHERE ${
@@ -196,9 +197,9 @@ export async function projectSearch(input: ProjectSearch) {
     ), projects AS (
       SELECT *
       FROM (
-        SELECT id, "projectType" from investment_projects
+        SELECT id, "projectType", NULL AS "detailplanId" from investment_projects
           UNION ALL
-        SELECT id, "projectType" from detailplan_projects
+        SELECT id, "projectType", "detailplanId" from detailplan_projects
       ) AS filtered_projects
       INNER JOIN all_projects ON all_projects.id = filtered_projects.id
     ), limited AS (

--- a/frontend/src/views/Project/Projects.tsx
+++ b/frontend/src/views/Project/Projects.tsx
@@ -113,6 +113,18 @@ function ProjectCard({ result }: { result: DbProject }) {
         <Box sx={{ display: 'flex', flexDirection: 'column' }}>
           <Typography sx={{ lineHeight: '120%' }} variant="button">
             {result.projectName}
+            {result.detailplanId && (
+              <>
+                ,{' '}
+                <span
+                  css={css`
+                    color: #aaa;
+                  `}
+                >
+                  ({result.detailplanId})
+                </span>
+              </>
+            )}
           </Typography>
           <Typography sx={{ lineHeight: '120%' }} variant="overline">
             {dayjs(result.startDate).format(tr('date.format'))} —{' '}

--- a/shared/src/schema/project/base.ts
+++ b/shared/src/schema/project/base.ts
@@ -23,6 +23,7 @@ export const dbProjectSchema = upsertProjectSchema.extend({
   id: z.string(),
   geom: z.string().nullable(),
   projectType: z.enum(projectTypes),
+  detailplanId: z.number().nullable(),
 });
 
 export type UpsertProject = z.infer<typeof upsertProjectSchema>;


### PR DESCRIPTION
- Pass `detailplanId` in the search results endpoint
- Display the detailplan ID (when available) after the project name in search result cards