### PR TITLE
Added version number to the logo title in UI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ on:
 env:
   NODE_VERSION: 18
   IMAGE_NAME: ${{ secrets.REGISTRY_ADDRESS }}/hanna
+  APP_VERSION: ${{ github.event_name == 'release' && github.event.release.name || format('build {0}', github.sha) }}
 
 jobs:
   test-frontend:
@@ -125,6 +126,8 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
+          build-args: |
+            APP_VERSION=${{ env.APP_VERSION }}
           tags: ${{ env.IMAGE_NAME }}:latest
           cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:latest
           cache-to: type=inline
@@ -153,7 +156,8 @@ jobs:
         with:
           push: true
           build-args: |
-            "EXTRA_HOSTS=${{ secrets.IMAGE_EXTRA_HOSTS }}"
+            EXTRA_HOSTS=${{ secrets.IMAGE_EXTRA_HOSTS }}
+            APP_VERSION=${{ env.APP_VERSION }}
           tags: ${{ env.IMAGE_NAME }}:${{ env.ENV_NAME }}
           cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:latest
           cache-to: type=inline

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,10 @@ RUN npm ci
 COPY frontend ./
 COPY backend ../backend
 
+# Build argument for the app version (to be injected into the application)
+ARG APP_VERSION
+ENV APP_VERSION ${APP_VERSION}
+
 RUN npm run build
 
 ###

--- a/frontend/src/Layout.tsx
+++ b/frontend/src/Layout.tsx
@@ -82,7 +82,7 @@ function Navbar() {
   return (
     <AppBar position="static">
       <Toolbar>
-        <Box sx={{ mr: 2 }}>
+        <Box sx={{ mr: 2 }} title={`Hanna ${APP_VERSION}`}>
           <Typography variant="h6" noWrap component="div" css={logoStyle}>
             Hanna
           </Typography>

--- a/frontend/types/vite.d.ts
+++ b/frontend/types/vite.d.ts
@@ -24,3 +24,8 @@ declare module '*.svg' {
   >
   export default ReactComponent
 }
+
+/**
+ * App version injected as a build-time global variable in Vite.
+ */
+declare const APP_VERSION: string;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,6 +11,7 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 // Use customized instance of MarkdownIt to enable anchor links
 const markdownIt = MarkdownIt({ html: true }).use(MarkdownItAnchor, {});
 
+const appVersion = process.env.APP_VERSION ?? 'local-dev';
 const backendHost = process.env.BACKEND_HOST ?? '127.0.0.1';
 const proxyAddress = `http://${backendHost}:3003`;
 
@@ -28,7 +29,7 @@ const serverOptions: CommonServerOptions = {
 export default defineConfig({
   plugins: [
     svgr(),
-    faviconsInject('./src/assets/logo.svg') as any,
+    process.env.NODE_ENV !== 'development' && (faviconsInject('./src/assets/logo.svg') as any),
     mdPlugin({
       mode: [Mode.REACT],
       markdownIt,
@@ -58,4 +59,7 @@ export default defineConfig({
     },
   },
   preview: serverOptions,
+  define: {
+    APP_VERSION: JSON.stringify(appVersion),
+  },
 });


### PR DESCRIPTION
- In GitHub workflow, use the new build argument `APP_VERSION`
  - For releases: use the actual release name as value
  - For test deployments: `build <commit-sha>`
  - For local development: `local-dev`
- In Vite, read `APP_VERSION` and use it as a build-time global variable in frontend code
- Use the app version in the logo component's `title` attribute