### PR TITLE
Disaple text wrap from numeric columns to make them responsive

### DIFF
--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -32,6 +32,7 @@ type ColumnSettings<TRow extends object> = {
     format?: (value: TRow[key], row?: TRow) => ReactNode;
     width?: number;
     align?: TableCellProps['align'];
+    type?: 'currency';
   };
 };
 
@@ -79,6 +80,8 @@ export function DataTable<TRow extends object, TQueryParams extends DataQueryPar
   const columnKeys = useMemo(() => {
     return Object.keys(columns) as (keyof typeof columns)[];
   }, [columns]);
+
+  const currencyColumnKeys = columnKeys.filter((key) => columns[key]?.type === 'currency');
 
   useEffect(() => {
     let shouldUpdate = true;
@@ -243,7 +246,11 @@ export function DataTable<TRow extends object, TQueryParams extends DataQueryPar
                       const formattedValue =
                         columns[key].format?.(row[key], row) ?? row[key]?.toString() ?? '';
                       return (
-                        <TableCell key={key.toString()} align={columns[key].align}>
+                        <TableCell
+                          sx={{ textWrap: currencyColumnKeys.includes(key) ? 'nowrap' : 'wrap' }}
+                          key={key.toString()}
+                          align={columns[key].align}
+                        >
                           {formattedValue}
                         </TableCell>
                       );

--- a/frontend/src/views/SapReports/BlanketContractReport.tsx
+++ b/frontend/src/views/SapReports/BlanketContractReport.tsx
@@ -54,6 +54,7 @@ export function BlanketContractReport() {
               return formatCurrency(value);
             },
             align: 'right',
+            type: 'currency',
           },
           totalDebit: {
             title: tr('sapReports.blanketContracts.totalDebit'),
@@ -61,6 +62,7 @@ export function BlanketContractReport() {
             format(value) {
               return formatCurrency(value ?? 0);
             },
+            type: 'currency',
           },
           totalCredit: {
             title: tr('sapReports.blanketContracts.totalCredit'),
@@ -68,6 +70,7 @@ export function BlanketContractReport() {
             format(value) {
               return formatCurrency(value ?? 0);
             },
+            type: 'currency',
           },
           totalActuals: {
             title: tr('sapReports.blanketContracts.totalActuals'),
@@ -75,6 +78,7 @@ export function BlanketContractReport() {
               return formatCurrency(value ?? 0);
             },
             align: 'right',
+            type: 'currency',
           },
         }}
       />

--- a/frontend/src/views/SapReports/EnvironmentalCodeReport.tsx
+++ b/frontend/src/views/SapReports/EnvironmentalCodeReport.tsx
@@ -71,6 +71,7 @@ export function EnvironmentalCodeReport() {
             format(value) {
               return formatCurrency(value ?? 0);
             },
+            type: 'currency',
           },
           totalCredit: {
             title: tr('sapReports.environmentCodes.totalCredit'),
@@ -78,6 +79,7 @@ export function EnvironmentalCodeReport() {
             format(value) {
               return formatCurrency(value ?? 0);
             },
+            type: 'currency',
           },
           totalActuals: {
             title: tr('sapReports.environmentCodes.totalActuals'),
@@ -85,6 +87,7 @@ export function EnvironmentalCodeReport() {
             format(value) {
               return formatCurrency(value ?? 0);
             },
+            type: 'currency',
           },
         }}
       />


### PR DESCRIPTION
- Disable wrapping from numeric columns of type `currency` to fix a bug where long negative values would wrap