### PR TITLE
Remove ext users from user selectors

### DIFF
--- a/backend/src/components/user/index.ts
+++ b/backend/src/components/user/index.ts
@@ -17,7 +17,7 @@ export async function getAllUsers() {
 export async function getAllNonExtUsers() {
   const users = await getPool().many(sql.type(userSchema)`
     SELECT id, email, name FROM app.user
-    WHERE email NOT LIKE '%@ext.tampere.fi%'
+    WHERE email NOT LIKE '%@ext.tampere.fi'
     ORDER BY name ASC
   `);
   return users;

--- a/backend/src/components/user/index.ts
+++ b/backend/src/components/user/index.ts
@@ -14,6 +14,15 @@ export async function getAllUsers() {
   return users;
 }
 
+export async function getAllNonExtUsers() {
+  const users = await getPool().many(sql.type(userSchema)`
+    SELECT id, email, name FROM app.user
+    WHERE email NOT LIKE '%@ext.tampere.fi%'
+    ORDER BY name ASC
+  `);
+  return users;
+}
+
 export async function getUser(id: string) {
   return await getPool().one(sql.type(userSchema)`
     ${userSelectFragment}

--- a/backend/src/router/user.ts
+++ b/backend/src/router/user.ts
@@ -1,9 +1,12 @@
-import { getAllUsers } from '@backend/components/user';
+import { getAllNonExtUsers, getAllUsers } from '@backend/components/user';
 import { TRPC } from '@backend/router';
 
 export const createUserRouter = (t: TRPC) =>
   t.router({
     getAll: t.procedure.query(async () => {
       return await getAllUsers();
+    }),
+    getAllNonExt: t.procedure.query(async () => {
+      return await getAllNonExtUsers();
     }),
   });

--- a/frontend/src/components/forms/UserSelect.tsx
+++ b/frontend/src/components/forms/UserSelect.tsx
@@ -27,7 +27,7 @@ type Props = {
 
 export function UserSelect(props: Props) {
   const { id, readOnly, onBlur, multiple, value, onChange, maxTags } = props;
-  const users = trpc.user.getAll.useQuery();
+  const users = trpc.user.getAllNonExt.useQuery();
 
   function getUser(userId: string) {
     return users.data?.find((user) => user.id === userId);

--- a/frontend/src/views/Project/Projects.tsx
+++ b/frontend/src/views/Project/Projects.tsx
@@ -42,7 +42,9 @@ function Toolbar() {
   const newProjectMenuAnchor = useRef<HTMLButtonElement>(null);
   return (
     <Box css={toolbarContainerStyle}>
-      <Typography variant="h4">{tr('pages.projectsTitle')}</Typography>
+      <Typography variant="h4" component="h1">
+        {tr('pages.projectsTitle')}
+      </Typography>
       <div>
         <Button
           ref={newProjectMenuAnchor}

--- a/frontend/src/views/WorkTable/ProjectObjectUsers.tsx
+++ b/frontend/src/views/WorkTable/ProjectObjectUsers.tsx
@@ -53,7 +53,7 @@ export function ProjectObjectUsers({ value }: { value: Value }) {
 export function ProjectObjectUserEdit({ value, onChange }: Props) {
   const tr = useTranslations();
   const anchorElRef = useRef<HTMLDivElement>(null);
-  const users = trpc.user.getAll.useQuery();
+  const users = trpc.user.getAllNonExt.useQuery();
   const [open, setOpen] = useState(false);
 
   useEffect(() => {


### PR DESCRIPTION
- Added new `getAllNonExtUsers` function to get all users without @ext.tampere.fi email for selectors
- Other option would be to modify the `getAllUsers` function to always disregard @ext.tampere.fi users
- Also changed one `<h>` tag to `<h1>`to make it semantically correct 