### PR TITLE
Add geoserver_user migration for local development

### DIFF
--- a/backend/.eslintrc.cjs
+++ b/backend/.eslintrc.cjs
@@ -3,7 +3,4 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],
   root: true,
-  env: {
-    node: true,
-  },
 };

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
     "dev:server": "tsx watch --clear-screen=false src/app.ts",
     "test": "vitest run",
     "db-migrate": "PGOPTIONS='-c search_path=app,public' tsx src/migration.ts",
+    "db-post-migrate": "PGOPTIONS='-c search_path=app,public' tsx src/postMigration.ts",
     "db-migrate:prod": "PGOPTIONS='-c search_path=app,public' node -r tsconfig-paths/register dist/migration.js"
   },
   "repository": {

--- a/backend/src/postMigration.ts
+++ b/backend/src/postMigration.ts
@@ -1,0 +1,26 @@
+import { createDatabasePool, getPool, sql } from './db';
+import { logger } from './logging';
+
+async function runPostMigration() {
+  await createDatabasePool();
+  try {
+    await getPool().any(sql.untyped`
+        CREATE ROLE geoserver;
+        GRANT CONNECT ON DATABASE app_dev_db TO geoserver;
+        GRANT USAGE ON SCHEMA app TO geoserver;
+        GRANT SELECT ON TABLE app.geoserver_street_objects TO geoserver;
+        CREATE user geoserver_user WITH PASSWORD 'geo_password';
+        GRANT geoserver to geoserver_user;
+    `);
+
+    logger.info('Geoserver user added to database');
+  } catch (error) {
+    let errorMessage = 'Error while adding geoserver user';
+    if (error instanceof Error) {
+      errorMessage += `: ${error.message}`;
+    }
+    logger.warn(errorMessage);
+  }
+}
+
+runPostMigration();


### PR DESCRIPTION
- Adding `geoserver_user` to test and prod turned out to be too complicated using migration so the user needs to be added manually to test and prod database (azure postgres flexible server shares users on prod and test so migrations wouldn't work with the same username)
- Added `postMigration` script to be able to locally add the user into the database