### PR TITLE
Make sap actuals document type optional

### DIFF
--- a/backend/src/components/sap/dataImport.ts
+++ b/backend/src/components/sap/dataImport.ts
@@ -340,7 +340,9 @@ async function insertActuals(conn: DatabaseTransactionConnection, actuals: SAPAc
         ${actual.currency},
         ${actual.valueInCurrencySubunit},
         ${actual.entryType},
-        ${actual.documentType},
+        ${
+          actual?.documentType ?? null
+        }, -- NOTE! Remove nullish coalescing after document type added to production
         ${actual.tradingPartnerId}
         );
     `);

--- a/backend/src/components/sap/environmentCodeReport.ts
+++ b/backend/src/components/sap/environmentCodeReport.ts
@@ -35,9 +35,12 @@ function environmentCodeReportFragment(params?: Partial<EnvironmentCodeReportQue
       ${
         years.length > 0
           ? sql.fragment`
-        WHERE fiscal_year = ANY(${sql.array(years, 'int4')}) AND document_type <> 'AA'
+        WHERE fiscal_year = ANY(${sql.array(
+          years,
+          'int4',
+        )}) AND document_type IS NULL OR document_type <> 'AA'
       `
-          : sql.fragment`WHERE document_type <> 'AA'`
+          : sql.fragment`WHERE document_type IS NULL OR document_type <> 'AA'`
       }
 	    GROUP BY wbs_element_id, trading_partner_id
     ),

--- a/shared/src/schema/sapActuals.ts
+++ b/shared/src/schema/sapActuals.ts
@@ -17,7 +17,7 @@ export const incomingItemSchema = z.object({
   TWAER: z.string(), // Currency
   WTGBTR: z.string(), // Total value in Transaction Currency
   BEKNZ: z.string(), // Debit / Credit Indicator
-  BLART: z.string().nullable(), // Document type of FI reference document
+  BLART: z.string().nullable().optional(), // Document type of FI reference document // NOTE!! optional until production SAP API is updated
   VBUND: z.string().nullable(), // Company ID of Trading Partner
 });
 
@@ -38,7 +38,7 @@ export const sapActualSchema = z.object({
   currency: z.string(),
   valueInCurrencySubunit: z.number().int(),
   entryType: z.enum(['DEBIT', 'CREDIT']),
-  documentType: z.string().nullable(),
+  documentType: z.string().nullable().optional(), // NOTE!! optional until production SAP API is updated
   tradingPartnerId: z.string().nullable(),
 });
 


### PR DESCRIPTION
- Make sap actuals document type optional as the field (BLART) is not yet available in production SAP API.