### PR TITLE
Limit project object type to one

### DIFF
--- a/backend/src/components/taskQueue/workTableReportQueue.ts
+++ b/backend/src/components/taskQueue/workTableReportQueue.ts
@@ -149,7 +149,8 @@ export async function setupWorkTableReportQueue() {
         projectEndDate: (row) => dayjs(row.projectDateRange.endDate).format(reportDateFormat),
         objectStartDate: (row) => dayjs(row.objectDateRange.startDate).format(reportDateFormat),
         objectEndDate: (row) => dayjs(row.objectDateRange.endDate).format(reportDateFormat),
-        objectType: (row) => formatIdArrayToText(row.objectType, 'objectType'),
+        objectType: (row) =>
+          codes.objectType.find((code) => row.objectType === code.id.id)?.text['fi'],
         objectCategory: (row) => formatIdArrayToText(row.objectCategory, 'objectCategory'),
         objectUsage: (row) => formatIdArrayToText(row.objectUsage, 'objectUsage'),
         committee: (row) => formatIdArrayToText([row.committee], 'committee'),

--- a/frontend/src/views/ProjectObject/InvestmentProjectObjectForm.tsx
+++ b/frontend/src/views/ProjectObject/InvestmentProjectObjectForm.tsx
@@ -397,13 +397,7 @@ export const InvestmentProjectObjectForm = forwardRef(function InvestmentProject
             errorTooltip={tr('projectObject.objectTypeTooltip')}
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             component={({ ref, ...field }) => (
-              <CodeSelect
-                {...field}
-                multiple
-                codeListId="KohdeTyyppi"
-                readOnly={!editing}
-                maxTags={3}
-              />
+              <CodeSelect {...field} codeListId="KohdeTyyppi" readOnly={!editing} />
             )}
           />
 

--- a/shared/src/schema/projectObject/investment.ts
+++ b/shared/src/schema/projectObject/investment.ts
@@ -6,7 +6,7 @@ import { commonDbProjectObjectSchema, newProjectObjectSchema } from './base.js';
 
 export const newInvestmentProjectObjectSchema = newProjectObjectSchema.extend({
   objectStage: codeId,
-  objectType: z.array(codeId).superRefine((value) => value.length > 0),
+  objectType: codeId,
   committee: nonEmptyString,
 });
 

--- a/shared/src/schema/projectObject/search.ts
+++ b/shared/src/schema/projectObject/search.ts
@@ -13,7 +13,7 @@ export const projectObjectSearchSchema = z.object({
   dateRange: periodSchema.optional(),
   map: mapSearchSchema.optional(),
   objectParticipantUser: nonEmptyString.nullish(),
-  objectTypes: mergedProjectObjectDbSchema.shape.objectType.optional(),
+  objectTypes: z.array(mergedProjectObjectDbSchema.shape.objectType).optional(),
   objectCategories: mergedProjectObjectDbSchema.shape.objectCategory.optional(),
   objectUsages: mergedProjectObjectDbSchema.shape.objectUsage.optional(),
   lifecycleStates: z.array(mergedProjectObjectDbSchema.shape.lifecycleState).optional(),

--- a/shared/src/schema/workTable.ts
+++ b/shared/src/schema/workTable.ts
@@ -57,7 +57,7 @@ export const workTableSearchSchema = z.object({
   projectObjectName: z.string().optional(),
   objectStartDate: dbInvestmentProjectObjectSchema.shape.startDate.optional().nullable(),
   objectEndDate: dbInvestmentProjectObjectSchema.shape.endDate.optional().nullable(),
-  objectType: dbInvestmentProjectObjectSchema.shape.objectType.optional(),
+  objectType: z.array(dbInvestmentProjectObjectSchema.shape.objectType).optional(),
   objectCategory: dbInvestmentProjectObjectSchema.shape.objectCategory.optional(),
   objectUsage: dbInvestmentProjectObjectSchema.shape.objectUsage.optional(),
   lifecycleState: z.array(dbInvestmentProjectObjectSchema.shape.lifecycleState).optional(),


### PR DESCRIPTION
Limited project object type to one. Possibly existing objects with multiple types use first type found. Should such object be updated, it saves that type and deletes the rest.