### PR TITLE
Fixed worktable writable field permissions

### DIFF
--- a/frontend/src/views/WorkTable/worktables/WorkTable.tsx
+++ b/frontend/src/views/WorkTable/worktables/WorkTable.tsx
@@ -409,7 +409,7 @@ export default function WorkTable() {
     } else if (hasPermission(auth, 'investmentFinancials.write')) {
       if (hasWritePermission(auth, permissionCtx) || ownsProject(auth, permissionCtx))
         writableFields = ['estimate', 'forecast', 'amount', 'kayttosuunnitelmanMuutos'];
-      writableFields = ['amount', 'kayttosuunnitelmanMuutos'];
+      else writableFields = ['amount', 'kayttosuunnitelmanMuutos'];
     } else if (hasWritePermission(auth, permissionCtx) || ownsProject(auth, permissionCtx)) {
       writableFields = ['estimate', 'forecast'];
     }


### PR DESCRIPTION
Due to there not being `else`, fields `'amount'` and `'kayttosuunnitelmanMuutos'` would always be the only writable fields in WorkTable, despite user permissions - fixed this