### PR TITLE
Fix/security updates

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@fastify/compress": "^8.3.1",
         "@fastify/cookie": "^11.0.2",
+        "@fastify/csrf-protection": "^8.0.0",
         "@fastify/formbody": "^8.0.2",
         "@fastify/http-proxy": "^11.4.1",
         "@fastify/passport": "^3.0.2",
@@ -756,6 +757,43 @@
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.0",
+        "fastify-plugin": "^5.0.0"
+      }
+    },
+    "node_modules/@fastify/csrf": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@fastify/csrf/-/csrf-8.0.1.tgz",
+      "integrity": "sha512-dAmCrdfJ3CV/A/hHHK/rRBjjLRRSIltgJB0BxiVfbhr/31G6fgF8l2I8evtH8mjS5kTIvd0JOh7MOA3HA6eYDw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/csrf-protection": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/csrf-protection/-/csrf-protection-8.0.0.tgz",
+      "integrity": "sha512-CG0XcZ74A80+vxPngj1uYUPb8SH808zUO4Ee9/mzRj8O2zUt0P6abCga1M9j5wV5I7U5aIL2mIXYLH8xno3E2w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/csrf": "^8.0.0",
+        "@fastify/error": "^4.0.0",
         "fastify-plugin": "^5.0.0"
       }
     },

--- a/backend/package.json
+++ b/backend/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "@fastify/compress": "^8.3.1",
     "@fastify/cookie": "^11.0.2",
+    "@fastify/csrf-protection": "^8.0.0",
     "@fastify/formbody": "^8.0.2",
     "@fastify/http-proxy": "^11.4.1",
     "@fastify/passport": "^3.0.2",

--- a/backend/src/apiKey.ts
+++ b/backend/src/apiKey.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'crypto';
 import { FastifyInstance, FastifyPluginOptions } from 'fastify';
 
 import { env } from './env.js';
@@ -13,12 +14,20 @@ interface Options {
   apis: FastifyRouteHandler[];
 }
 
+function safeCompare(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  return bufA.length === bufB.length && timingSafeEqual(bufA, bufB);
+}
+
 export function registerApiKeyRoutes(server: FastifyInstance, opts: Options) {
   server.register(
     (server, _opts, done) => {
       server.addHook('preValidation', async (req, reply) => {
+        const apiKey = req.headers['x-api-key'];
+
         // Deny access when no API key has been defined or the given api key doesn't match
-        if (!env.adminApiKey || req.headers['x-api-key'] !== env.adminApiKey) {
+        if (!env.adminApiKey || typeof apiKey !== 'string' || !safeCompare(apiKey, env.adminApiKey)) {
           reply.code(401);
           throw new Error('Unauthorized');
         }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -121,8 +121,7 @@ async function run() {
     prefix: '/',
   });
 
-  server.get('/api/v1/ping', async (req) => {
-    logger.info(`Ping request received, headers: ${JSON.stringify(req.headers)}, ips: ${req.ips}`);
+  server.get('/api/v1/ping', async () => {
     return { ping: 'pong', now: new Date() };
   });
 

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -33,6 +33,13 @@ interface AuthPluginOpts extends FastifyPluginOptions {
   publicRouterPaths: Set<string>;
 }
 
+function safeRedirect(target?: string): string {
+  if (!target || !target.startsWith('/') || target.startsWith('//') || target.startsWith('/\\')) {
+    return '/';
+  }
+  return target;
+}
+
 function getUserRole(roles: string[]): UserRole {
   if (roles.includes(env.adminGroup as string)) {
     return 'Hanna.Admin';
@@ -169,7 +176,7 @@ export function registerAuth(fastify: FastifyInstance, opts: AuthPluginOpts) {
     await fastifyPassport
       .authenticate('oidc', async (req, res, error, user) => {
         // Get redirect url here because the session is cleared after login
-        const redirectPath = req.session.get('redirectUrl') ?? '/';
+        const redirectPath = safeRedirect(req.session.get('redirectUrl'));
         // If there are errors in login (e.g. already used or expired code), redirect to the front page
         if (error || !user) {
           return res.redirect('/');

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -1,4 +1,5 @@
 import fastifyCookie from '@fastify/cookie';
+import fastifyCsrfProtection from '@fastify/csrf-protection';
 import formBody from '@fastify/formbody';
 import { Authenticator } from '@fastify/passport';
 import fastifySession from '@fastify/session';
@@ -70,6 +71,8 @@ export function registerAuth(fastify: FastifyInstance, opts: AuthPluginOpts) {
     },
   });
 
+  fastify.register(fastifyCsrfProtection, { sessionPlugin: '@fastify/session' });
+
   const fastifyPassport = new Authenticator();
   fastify.register(fastifyPassport.initialize());
   fastify.register(fastifyPassport.secureSession());
@@ -127,9 +130,18 @@ export function registerAuth(fastify: FastifyInstance, opts: AuthPluginOpts) {
     }
   });
 
-  fastify.get('/api/v1/auth/user', async (req) => {
+  fastify.addHook('preValidation', (req, reply, done) => {
+    if (req.method === 'POST' && req.url.startsWith('/trpc')) {
+      fastify.csrfProtection(req, reply, done);
+    } else {
+      done();
+    }
+  });
+
+  fastify.get('/api/v1/auth/user', async (req, reply) => {
     if (req.user) {
-      return req.user;
+      const user = JSON.parse(req.user as any);
+      return { ...user, csrfToken: reply.generateCsrf() };
     }
   });
 

--- a/backend/src/csrfProtection.spec.ts
+++ b/backend/src/csrfProtection.spec.ts
@@ -1,0 +1,109 @@
+import cookie from '@fastify/cookie';
+import csrfProtection from '@fastify/csrf-protection';
+import session from '@fastify/session';
+import Fastify, { FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// Mirrors the exact plugin registration and hook used in auth.ts, minus OIDC/DB wiring,
+// so the test exercises the real @fastify/csrf-protection + @fastify/session behavior.
+function buildServer() {
+  const fastify = Fastify();
+  fastify.register(cookie);
+  fastify.register(session, { secret: 'a'.repeat(32), cookie: { secure: false } });
+  fastify.register(csrfProtection, { sessionPlugin: '@fastify/session' });
+
+  fastify.addHook('preValidation', (req, reply, done) => {
+    if (req.method === 'POST' && req.url.startsWith('/trpc')) {
+      fastify.csrfProtection(req, reply, done);
+    } else {
+      done();
+    }
+  });
+
+  fastify.get('/auth/user', async (_req, reply) => {
+    return { csrfToken: reply.generateCsrf() };
+  });
+
+  fastify.get('/trpc/some.query', async () => ({ ok: true }));
+  fastify.post('/trpc/some.mutation', async () => ({ ok: true }));
+
+  return fastify;
+}
+
+function getSessionCookie(response: { cookies: { name: string; value: string }[] }) {
+  const sessionCookie = response.cookies.find((c) => c.name === 'sessionId');
+  return `${sessionCookie?.name}=${sessionCookie?.value}`;
+}
+
+describe('csrf protection', () => {
+  let fastify: FastifyInstance;
+
+  beforeEach(async () => {
+    fastify = buildServer();
+    await fastify.ready();
+  });
+
+  afterEach(async () => {
+    await fastify.close();
+  });
+
+  it('rejects a POST /trpc mutation with no session/token at all', async () => {
+    const response = await fastify.inject({ method: 'POST', url: '/trpc/some.mutation' });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json().code).toBe('FST_CSRF_MISSING_SECRET');
+  });
+
+  it('rejects a POST /trpc mutation carrying a valid session but a wrong token', async () => {
+    const tokenResponse = await fastify.inject({ method: 'GET', url: '/auth/user' });
+    const sessionCookie = getSessionCookie(tokenResponse);
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/trpc/some.mutation',
+      headers: { cookie: sessionCookie, 'csrf-token': 'not-the-real-token' },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json().code).toBe('FST_CSRF_INVALID_TOKEN');
+  });
+
+  it('accepts a POST /trpc mutation carrying the token issued for that session', async () => {
+    const tokenResponse = await fastify.inject({ method: 'GET', url: '/auth/user' });
+    const sessionCookie = getSessionCookie(tokenResponse);
+    const { csrfToken } = tokenResponse.json();
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/trpc/some.mutation',
+      headers: { cookie: sessionCookie, 'csrf-token': csrfToken },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ ok: true });
+  });
+
+  it('does not gate GET /trpc queries at all', async () => {
+    const response = await fastify.inject({ method: 'GET', url: '/trpc/some.query' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ ok: true });
+  });
+
+  it('rejects a token issued for a different session', async () => {
+    const firstToken = await fastify.inject({ method: 'GET', url: '/auth/user' });
+    const { csrfToken } = firstToken.json();
+
+    const secondSession = await fastify.inject({ method: 'GET', url: '/auth/user' });
+    const secondSessionCookie = getSessionCookie(secondSession);
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/trpc/some.mutation',
+      headers: { cookie: secondSessionCookie, 'csrf-token': csrfToken },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json().code).toBe('FST_CSRF_INVALID_TOKEN');
+  });
+});

--- a/e2e/utils/trpc.ts
+++ b/e2e/utils/trpc.ts
@@ -22,6 +22,14 @@ export async function createTRPCClient(page: Page) {
     rejectUnauthorized: false,
   });
   const cookies = await page.context().cookies();
+  const cookieHeader = getCookieHeaderValue(cookies);
+
+  const userResponse = await nodeFetch('https://localhost:1443/api/v1/auth/user', {
+    agent,
+    headers: { cookie: cookieHeader },
+  } as RequestInit);
+  const { csrfToken } = (await userResponse.json()) as { csrfToken: string };
+
   return createTRPCProxyClient<AppRouter>({
     links: [
       httpLink({
@@ -32,7 +40,8 @@ export async function createTRPCClient(page: Page) {
             agent,
             headers: {
               ...(options?.headers),
-              cookie: getCookieHeaderValue(cookies),
+              cookie: cookieHeader,
+              'csrf-token': csrfToken,
             },
           } as RequestInit);
         },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,8 @@ import SuperJSON from 'superjson';
 
 import { Layout } from '@frontend/Layout';
 import { trpc } from '@frontend/client';
-import { asyncUserAtom, sessionExpiredAtom } from '@frontend/stores/auth';
+import { csrfAwareFetch } from '@frontend/csrfFetch';
+import { asyncUserAtom, getCsrfToken, refreshCsrfToken, sessionExpiredAtom } from '@frontend/stores/auth';
 import { useTranslations } from '@frontend/stores/lang';
 import { MaintenanceProject } from '@frontend/views/MaintenanceProject/MaintenanceProject';
 import { Management } from '@frontend/views/Management';
@@ -105,7 +106,8 @@ export function App() {
           url: '/trpc',
           // Override fetch function to intercept all TRPC response status codes for detecting expired sessions
           async fetch(url, options) {
-            const result = await fetch(url, { ...options });
+            const result = await csrfAwareFetch(url, options, { getCsrfToken, refreshCsrfToken });
+
             if (result.status === 401) {
               // Any 401 error in TRPC responses -> session has been expired
               if (!sessionExpired) {

--- a/frontend/src/csrfFetch.ts
+++ b/frontend/src/csrfFetch.ts
@@ -1,0 +1,35 @@
+const csrfErrorCodes = new Set(['FST_CSRF_INVALID_TOKEN', 'FST_CSRF_MISSING_SECRET']);
+
+interface CsrfFetchDeps {
+  getCsrfToken: () => string | undefined;
+  refreshCsrfToken: () => Promise<string | undefined>;
+  fetchImpl?: typeof fetch;
+}
+
+
+export async function csrfAwareFetch(
+  url: Parameters<typeof fetch>[0],
+  options: RequestInit | undefined,
+  deps: CsrfFetchDeps,
+): Promise<Response> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const withCsrfHeader = () => ({
+    ...options,
+    headers: { ...options?.headers, 'csrf-token': deps.getCsrfToken() ?? '' },
+  });
+
+  let result = await fetchImpl(url, withCsrfHeader());
+
+  if (result.status === 403) {
+    const body = await result
+      .clone()
+      .json()
+      .catch(() => null);
+    if (csrfErrorCodes.has(body?.code)) {
+      await deps.refreshCsrfToken();
+      result = await fetchImpl(url, withCsrfHeader());
+    }
+  }
+
+  return result;
+}

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -5,6 +5,16 @@ import { User } from '@shared/schema/user';
 
 export const sessionExpiredAtom = atom<boolean>(false);
 
+type UserResponse = User & { csrfToken: string };
+
+// Kept outside of jotai state since the trpc client's fetch override needs to read/write it
+// synchronously on every request, without subscribing to React state changes.
+let csrfToken: string | undefined;
+
+export function getCsrfToken() {
+  return csrfToken;
+}
+
 async function getUser() {
   const resp = await fetch('/api/v1/auth/user');
   if (resp.status === 401) {
@@ -13,7 +23,16 @@ async function getUser() {
       window.location.pathname,
     )}`;
   }
-  return (await resp.json()) as User;
+  const data = (await resp.json()) as UserResponse;
+  csrfToken = data.csrfToken;
+  return data;
+}
+
+// Re-fetches the csrf token when a mutation reports it as stale/missing (e.g. after the
+// session was renewed or the previous token's secret rotated).
+export async function refreshCsrfToken() {
+  await getUser();
+  return csrfToken;
 }
 
 export const asyncUserAtom = atomWithRefresh<Promise<User>>(async () => getUser());


### PR DESCRIPTION
- Removed request headers/cookies from being logged on the /ping endpoint.
- Made OIDC login redirects safe (safeRedirect), preventing open-redirect via the redirect query param.
- Switched the admin API key check to a constant-time comparison, preventing timing-attack key recovery.
- Added CSRF protection: registered @fastify/csrf-protection in session mode, gated POST /trpc/* behind it, issue the token via /api/v1/auth/user, added frontend retry-on-stale-token logic (csrfFetch.ts), and a backend integration test verifying the real Fastify/CSRF behavior.